### PR TITLE
add course short code to event in calendar event

### DIFF
--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -629,7 +629,7 @@ class CalendarEvent < ActiveRecord::Base
         event.end = event.start
         event.end.ical_params = {"VALUE"=>["DATE"]}
       end
-      event.summary = @event.title
+      event.summary = (@event.context_type == "Course" && "#{@event.title} (#{@event.context.course_code})" || @event.title)   #event.summary = @event.title
       if @event.description
         html = api_user_content(@event.description, @event.context)
         event.description html_to_text(html)


### PR DESCRIPTION
The ICS feed provides a single calendar for all the user's courses. It does
not include the course name anywhere in the event. This would be confusing
if, for example, you had two events called "Midterm Exam" in the same week.
