### PR TITLE
Fix regression causing "Start a New Course" button to not display

### DIFF
--- a/app/views/users/dashboard_sidebar.html.erb
+++ b/app/views/users/dashboard_sidebar.html.erb
@@ -14,14 +14,9 @@
 <% if @show_recent_feedback %>
 <%= render :partial => "shared/event_list", :object => @recent_feedback, :locals => {:title => t('recent_feedback', "Recent Feedback"), :display_count => 3, :period => :two_weeks, :show_context => true, :is_recent_feedback => true} %>
 <% end %>
-<% if show_user_create_course_button(@current_user) %>
-<div class="rs-margin-lr">
 <div class="rs-margin-lr">
   <button type="button"
           id="sfu_course_form"
           class="element_toggler btn button-sidebar-wide"
           onclick="window.location.href='/sfu/course/new'"><%= t('sfu_course_form', 'Start a New Course') %></button>
-  </div>
-<%= render :partial => 'shared/new_course_form' %>
 </div>
-<% end %>


### PR DESCRIPTION
Carson reported (https://rt.sfu.ca/Ticket/Display.html?id=263353) that the Start a New Course button is no longer showing up. The `if` statement to check `show_user_create_course_button` is not needed for our button.

The code now matches 2fbc47803891ace6d5d4c2a9cd0e2229f9479693
