### PR TITLE
Section name for tutorials was missing the Course Code.

### DIFF
--- a/vendor/plugins/sfu_course_form/app/controllers/course_form_controller.rb
+++ b/vendor/plugins/sfu_course_form/app/controllers/course_form_controller.rb
@@ -151,7 +151,7 @@ class CourseFormController < ApplicationController
     unless course["section_tutorials"].nil?
       course["section_tutorials"].split(",").compact.uniq.each do |tutorial_name|
         section_id = "#{course["term"]}-#{course["name"]}-#{course["number"]}-#{tutorial_name.downcase}:::section"
-        sections.push "#{section_id}:_:#{tutorial_name.upcase}"
+        sections.push "#{section_id}:_:#{course["name"].upcase}#{course["number"]} #{tutorial_name.upcase}"
       end
     end
 


### PR DESCRIPTION
Making section name consistent throughout to have Course Code in the section name (e.g. PHYS141 D100, PHYS141 D101).

Hopefully last pull request before code freeze =)
