### PR TITLE
css and js fixes for the no-logged-in-user case

### DIFF
--- a/public/sfu/css/sfu.css
+++ b/public/sfu/css/sfu.css
@@ -7,12 +7,17 @@
     background: #494950 url(../images/bg-small.png) -70px 0 no-repeat;
 }
 
-#header-logo {
+#header-logo, #header.no-user #header-logo {
     background: url(../images/sfu-canvas-logo@2x.png) 0 0 no-repeat;
     background-size: 140px 50px;
     width: 140px;
     height: 50px;
     bottom: 0;
+}
+
+#header.no-user #header-logo {
+    top: 16px;
+    left: 16px;
 }
 
 .ie8 #header-logo {

--- a/public/sfu/sfu.js
+++ b/public/sfu/sfu.js
@@ -5,6 +5,18 @@
     $('footer').html('<a href="http://www.sfu.ca/canvas"><img alt="SFU Canvas" src="/sfu/images/sfu-logo.png" width="250" height="38"></a>').show();
 })(jQuery);
 
+// handle no-user case
+(function($) {
+	if ($('#header').hasClass('no-user')) {
+		console.log('no-user');
+		// add in a dummy #menu div
+		$('#header-inner').append('<div id="menu" style="height:41px"></div>');
+		// remove the register link
+		$('#header.no-user a[href="/register"]').parent().remove()
+	}
+})(jQuery);
+
+
 // google analytics
 if (window.location.hostname && 'canvas.sfu.ca' === window.location.hostname) {
     var _gaq = _gaq || [];


### PR DESCRIPTION
When a user is not logged in, canvas throws a 'no-user' class on #header, which screwed up our customizations. This fixes it, as well as removes the link to /register.
