### PR TITLE
Modify the sfu_api plugin to use the existing canvas oauth system.

### DIFF
--- a/vendor/plugins/sfu_api/lib/sfu/api/routing.rb
+++ b/vendor/plugins/sfu_api/lib/sfu/api/routing.rb
@@ -3,14 +3,14 @@ module SFU #:nodoc:
     module Routing #:nodoc:
       module MapperExtensions
         def api_urls
-          @set.add_route("/sfu/api/course/:sis_id/:property", {:controller => "api", :action => "course", :property => nil})
-          @set.add_route("/sfu/api/user/:sfu_id/:property", {:controller => "api", :action => "user", :property => nil})
-          @set.add_route("/sfu/api/courses/teaching/:sfuid/:term", {:controller => "api", :action => "courses", :term => nil})
+          @set.add_route("/sfu/api/course/:sis_id/:property", {:controller => "api", :action => "course", :property => nil, :format => 'json'})
+          @set.add_route("/sfu/api/user/:sfu_id/:property", {:controller => "api", :action => "user", :property => nil, :format => 'json'})
+          @set.add_route("/sfu/api/courses/teaching/:sfuid/:term", {:controller => "api", :action => "courses", :term => nil, :format => 'json'})
         end
 
       end
     end
   end
-end 
+end
 
 ActionController::Routing::RouteSet::Mapper.send :include, SFU::Api::Routing::MapperExtensions


### PR DESCRIPTION
override api_request? to always return true

check authorized_action in user method

force api routes to JSON

not all routes require authentication

remove unused require statements

switch from render :text to render :json

add 404s where appropriate

allow unrestricted access to /users/:id/terms (only)

downcase the sis_id, just in case

remove requires_auth_token? method

return to simple api_request? method

always return true

make .../user/:sfu_id/uuid return JSON instead of text
