### PR TITLE
Hotfix deploy & pretty output

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "bundler/capistrano"
 set :stages,        %w(production staging testing vm)
 set :default_stage, "testing"
@@ -41,7 +42,6 @@ namespace :deploy do
 	task :stop do ; end
 	desc 'Signal Passenger to restart the application.'
  	task :restart, :except => { :no_release => true } do
-    puts "Signal Passenger to restart: touching #{release_path}/tmp/restart.txt"
 		run "touch #{release_path}/tmp/restart.txt"
     # run "sudo /etc/init.d/httpd restart"
 	end
@@ -122,3 +122,128 @@ before("deploy:create_symlink", "canvas:update_remote")
 
 after(:deploy, "deploy:cleanup")
 after(:deploy, "deploy:web:enable") unless is_hotfix?
+
+####### PRETTY OUTPUT
+unless (ENV.has_key?('verbose') && ENV['verbose'].downcase == "true")
+  logger.level = Logger::IMPORTANT
+  require "colored"
+  STDOUT.sync
+
+  def yellow_arrow
+    "→".yellow
+  end
+
+  def buffered_string(str)
+    len = 60;
+    str = "#{yellow_arrow} #{str}"
+    while (str.length < len) do
+      str += '.'
+    end
+    str
+  end
+
+  before "deploy:web:disable" do
+      print buffered_string "Putting up maintenance page"
+  end
+
+  after "deploy:web:disable" do
+      puts "✓".green
+  end
+
+  before "deploy:web:enable" do
+      print buffered_string "Removing maintenance page"
+  end
+
+  after "deploy:web:enable" do
+      puts "✓".green
+  end
+
+
+  before "deploy:update_code" do
+      print buffered_string "Updating Code"
+  end
+
+  after "deploy:update_code" do
+      puts "✓".green
+  end
+
+  before "deploy:cleanup" do
+      print buffered_string "Cleaning up"
+  end
+
+  after "deploy:cleanup" do
+      puts "✓".green
+  end
+
+  before "canvas:compile_assets" do
+      print buffered_string "Compiling static assets"
+  end
+
+  after "canvas:compile_assets" do
+      puts "✓".green
+  end
+
+  before "canvas:symlink_canvasfiles" do
+      print buffered_string "Symlinking Canvas data files"
+  end
+
+  after "canvas:symlink_canvasfiles" do
+      puts "✓".green
+  end
+
+  before "canvas:clone_qtimigrationtool" do
+      print buffered_string "Installing QTIMigrationTool"
+  end
+
+  after "canvas:clone_qtimigrationtool" do
+      puts "✓".green
+  end
+
+  before "deploy:migrate" do
+      print buffered_string "Performing DB migration"
+  end
+
+  after "deploy:migrate" do
+      puts "✓".green
+  end
+
+  before "canvas:load_notifications" do
+      print buffered_string "Loading Canvas notifications"
+  end
+
+  after "canvas:load_notifications" do
+      puts "✓".green
+  end
+
+  before "canvas:restart_jobs" do
+      print buffered_string "Restarting delayed jobs"
+  end
+
+  after "canvas:restart_jobs" do
+      puts "✓".green
+  end
+
+  before "canvas:log_deploy" do
+      print buffered_string "Logging deploy to stats.its.sfu.ca"
+  end
+
+  after "canvas:log_deploy" do
+      puts "✓".green
+  end
+
+  before "canvas:copy_config" do
+      print buffered_string "Copying config files"
+  end
+
+  after "canvas:copy_config" do
+      puts "✓".green
+  end
+
+  before "deploy:create_symlink" do
+    print buffered_string "Moving the current version symlink"
+  end
+
+  after "deploy:create_symlink" do
+      puts "✓".green
+  end
+end


### PR DESCRIPTION
Two changes:
1. Allow a hotfix deploy. Ahotfix deploy is similar to a normal deploy, except:
- the maintenance page is not shown
- db migrations are not run
- load notifications are not run

The app remains available until the deploy is completed, at which point the symlink is moved and Passenger restarts the app.
1. Allow pretty output. Suppresses the default verbose output and gives the pretty. The old verbose mode can be enabled with the `verbose=true` env var.
