### PR TITLE
remove sfu-specific lines from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,10 +43,3 @@
 /public/javascripts/plugins/
 /public/plugins/
 /spec/coffeescripts/plugins/
-
-# SFU-specific ignores
-/config/*.yml.*
-/mnt/*
-/cache
-/public/google*.html
-/config/deploy/vm.rb


### PR DESCRIPTION
Having our own stuff in .gitignore makes merging a pain. Turns out none of these really need to be here. If you need to ignore stuff in your own clone of the repo (or your fork), such as a config/deploy/vm.rb file, put it in .git/info/excludes.
