### PR TITLE
Redo CANVAS-206 (remove EtherPad deletion warning)

### DIFF
--- a/app/views/collaborations/_forms.html.erb
+++ b/app/views/collaborations/_forms.html.erb
@@ -27,11 +27,12 @@
   </tr><tr id="etherpad_description" style="display: none;" class="collaboration_type">
     <td colspan="2" style="padding: 5px 20px 10px">
       <%= image_tag "ether_pad.png", :style => "float: right; margin-left: 15px; margin-top: 5px;" %>
-      <% # CANVAS-206 Removed irrelevant EtherPad deletion policy warning %>
-      <%= mt 'descriptions.etherpad', <<-HEREDOC, :etherpad_deletion_policy_url => "http://titanpad.com/ep/pro-help/#deletionpolicy"
-EtherPad is an open source project that lets you quickly set up shared documents.  It's fast enough that you can see what others are typing as they're typing it. On the other hand, "pads" aren't protected by a password so anyone with a link to them can edit them. EtherPad is better suited than Google Docs if you want to support anonymity and/or allowing people without Google accounts to participate.  \n  \n**Warning**: be sure you are familiar with [EtherPad's deletion policy](%{etherpad_deletion_policy_url}) to ensure your work is preserved.
+      <% # SFU MOD CANVAS-206 Removed irrelevant EtherPad deletion policy warning %>
+      <%= mt 'descriptions.etherpad', <<-HEREDOC
+EtherPad is an open source project that lets you quickly set up shared documents.  It's fast enough that you can see what others are typing as they're typing it. On the other hand, "pads" aren't protected by a password so anyone with a link to them can edit them. EtherPad is better suited than Google Docs if you want to support anonymity and/or allowing people without Google accounts to participate.
 HEREDOC
         %>
+      <% # END SFU MOD %>
     </td>
   </tr><tr class="collaborate_data">
     <td style="white-space: nowrap">


### PR DESCRIPTION
A previous change was overwritten by a merge of tag
'tags/release/2013-07-13.24'.

Previous commit: 86ec8194ce446d6c9530ef9e98c128ca4253a51a
Overwriting commit: 72566073a9e15a81e33ea4b668ac457bc6a72813
