### PR TITLE
Fix for overlength errors when creating courses

### DIFF
--- a/vendor/plugins/sfu_course_form/app/views/course_form/new.html.erb
+++ b/vendor/plugins/sfu_course_form/app/views/course_form/new.html.erb
@@ -97,7 +97,7 @@
   </div>
   <div class="control-group">
     <label for="txt-course_name" class="control-label">Course Name</label>
-    <div class="controls"><input type="text" id="txt-course_name" name="course_name" /></div>
+    <div class="controls"><input type="text" id="txt-course_name" name="course_name" maxlength="255" /></div>
   </div>
   <div class="actions">
     <button type="button" id="action-submit-non_calendar" class="action btn btn-primary">Create Non-Credit Course</button>


### PR DESCRIPTION
The SIS batch import created by the Start a New Course form will fail silently if `long_name` is longer than 255 characters (= max length of corresponding field in the database). There have been two tickets related to this issue (#317466 and #318781).

This fix attempts to shorten any overlength cross-listed course names, and warns the user if it is unable to shorten the name enough.
