### PR TITLE
Deleting trailing ':::course' from cross-list sis_source_id

### DIFF
--- a/vendor/plugins/sfu_course_form/app/controllers/course_form_controller.rb
+++ b/vendor/plugins/sfu_course_form/app/controllers/course_form_controller.rb
@@ -108,7 +108,7 @@ class CourseFormController < ApplicationController
         sections.push course_info["sections"]
       end
 
-      course_id = "#{course_ids.join(':')}:::course"
+      course_id = course_ids.join(':')
       short_name = short_names.join(' / ')
       long_name = long_names.join(' / ')
 


### PR DESCRIPTION
Not needed or being used
