### PR TITLE
Hide self-register link if self registration is off (CANVAS-233)

### DIFF
--- a/app/views/courses/settings.html.erb
+++ b/app/views/courses/settings.html.erb
@@ -243,13 +243,21 @@ TEXT
         <td></td>
         <td colspan="3">
           <span class="self_enrollment_message" style="<%= hidden unless @context.self_enrollment %>">
-            <%= t 'course_open_enrollment', <<-TEXT, :url => enroll_url(@context.self_enrollment_code || '{{ self_enrollment_code }}'), :url2 => register_url, :code => @context.self_enrollment_code || '{{ self_enrollment_code }}', :wrapper => '<b>\1</b>'
+            <% # BEGIN SFU MOD CANVAS-233 Hide self-enroll register link if self registration is off %>
+            <%= t 'course_open_enrollment', <<-TEXT, :url => enroll_url(@context.self_enrollment_code || '{{ self_enrollment_code }}'), :wrapper => '<b>\1</b>'
                   This course has enabled open enrollment. Students can
                   self-enroll in the course once you share with them this URL:
-                  *%{url}*. Alternatively, they can sign up at *%{url2}* and
-                  use the following join code: *%{code}*
+                  *%{url}*.
                 TEXT
             %>
+            <% if @context.root_account.self_registration? %>
+              <%= t 'course_self_registration', <<-TEXT, :url2 => register_url, :code => @context.self_enrollment_code || '{{ self_enrollment_code }}', :wrapper => '<b>\1</b>'
+                    Alternatively, they can sign up at *%{url2}* and
+                    use the following join code: *%{code}*
+                  TEXT
+              %>
+            <% end %>
+            <% # END SFU MOD %>
           </span>
           <a href="#" class="course_form course_form_more_options_link" style="padding-left: 20px;"><%= t('links.more_options', %{more options}) %></a>
           <div class="course_form_more_options" style="display: none; padding-left: 20px;">

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -4101,7 +4101,10 @@ en:
         add_section: "Add Section"
         move_course: "Move Course"
         update_course: "Update Course Details"
-      course_open_enrollment: "This course has enabled open enrollment. Students can self-enroll in the course once you share with them this URL: *%{url}*. Alternatively, they can sign up at *%{url2}* and use the following join code: *%{code}*"
+      # BEGIN SFU MOD CANVAS-233 Hide self-enroll register link if self registration is off
+      course_open_enrollment: "This course has enabled open enrollment. Students can self-enroll in the course once you share with them this URL: *%{url}*."
+      course_self_registration: "Alternatively, they can sign up at *%{url2}* and use the following join code: *%{code}*"
+      # END SFU MOD
       course_overrides_term: "This will override any term availability settings."
       date_restricted: "Users can only participate in the course between these dates"
       deatils: 


### PR DESCRIPTION
This involves splitting `course_open_enrollment` into two separate localized strings. The second half contains the self-register link.
