### PR TITLE
Fix hijacking of Start New Course button in IE

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -18,27 +18,39 @@
 
     // hijack Start New Course button (CANVAS-192)
     // first, cache the original event handler and disable it
-    var eventlist = jQuery._data( document, "events" ).click,
-        targetSelector = '.element_toggler[aria-controls]',
-        origHandler, e;
-    // cache the handler
-    for (var i = 0; i < eventlist.length; i++) {
-        e = eventlist[i];
-        if (e.selector === targetSelector) {
-            origHandler = e.handler;
+    function hijackStartNewCourseButton() {
+        if (!jQuery._data(document, "events")) {
+            // bit of a hack for IE which seems to randomly not have the events
+            // loaded by the time this script loads
+            window.setTimeout(hijackStartNewCourseButton, 100);
+        } else {
+            var eventlist = jQuery._data( document, "events" ).click,
+                targetSelector = '.element_toggler[aria-controls]',
+                origHandler, e;
+            // cache the handler
+            for (var i = 0; i < eventlist.length; i++) {
+                e = eventlist[i];
+                if (e.selector === targetSelector) {
+                    origHandler = e.handler;
+                }
+            }
+            if (origHandler) {
+                // remove the handler, and add our own
+                $(document).off('click change', targetSelector).on('click change', targetSelector, function(event) {
+                    if (this.id === 'start_new_course') {
+                        event.stopImmediatePropagation();
+                        window.location = '/sfu/course/new';
+                    } else {
+                        origHandler.call(this, event);
+                    }
+                });
+            }
         }
     }
-    if (origHandler) {
-        // remove the handler, and add our own
-        $(document).off('click change', targetSelector).on('click change', targetSelector, function(event) {
-            if (this.id === 'start_new_course') {
-                event.stopImmediatePropagation();
-                window.location = '/sfu/course/new';
-            } else {
-                origHandler.call(this, event);
-            }
-        });
-    }
+    $(document).ready(function() {
+        hijackStartNewCourseButton();
+    });
+
     // END CANVAS-192
 
     // FIX (temporary) for no-flash browsers to upload files using the Files tool


### PR DESCRIPTION
The "Start New Course" button on the main dashboard was randomly bringing up the standard built-in Canvas form instead of redirecting to the SFU form. The right-hand sidebar gets loaded via ajax, and for some reason the event that I'm overriding wasn't present on the page at that time, only in IE. This fix checks for the presence of that object first, and if it isn't found, waits 100ms and tries again. Tested on IE 9 & 10, FF and Chrome. **Note**: this was already changed in-place on ap1..10; which is why I'm doing a pull request against sfu-deploy. Once merged I'll pull it into sfu-develop as well.
