### PR TITLE
Add API to undelete group membership

### DIFF
--- a/vendor/plugins/sfu_api/app/controllers/api_controller.rb
+++ b/vendor/plugins/sfu_api/app/controllers/api_controller.rb
@@ -230,4 +230,13 @@ class ApiController < ApplicationController
     end
   end
 
+  def undelete_group_membership
+    membership = GroupMembership.find(params[:id])
+    membership.workflow_state = 'accepted'
+    if membership.save
+      render :json => membership.as_json(:include_root => false, :only => %w(id group_id user_id workflow_state moderator))
+    else
+      render :json => membership.errors, :status => :bad_request
+    end
+  end
 end

--- a/vendor/plugins/sfu_api/lib/sfu/api/routing.rb
+++ b/vendor/plugins/sfu_api/lib/sfu/api/routing.rb
@@ -23,6 +23,7 @@ module SFU #:nodoc:
           @set.add_route("/sfu/api/v1/amaint/user/:sfu_id/:property/:filter", {:controller => "amaint", :action => "user_info", :property => nil, :filter => nil, :format => 'json'})
           @set.add_route("/sfu/api/v1/amaint/course/:sis_id/:property", {:controller => "amaint", :action => "course_info", :property => nil, :format => 'json'})
           @set.add_route("/sfu/api/v1/enrollment", {:controller => "api", :action => "course_enrollment", :method => :post})
+          @set.add_route("/sfu/api/v1/group_memberships/:id/undelete", {:controller => "api", :action => "undelete_group_membership", :method => :put})
         end
 
       end


### PR DESCRIPTION
This is for if we decide to go with "Plan A" and re-add (un-delete) group memberships after converting manual enrollments to auto.
