### PR TITLE
Prevent students from viewing courses on test systems

### DIFF
--- a/vendor/plugins/sfu_test_cluster/init.rb
+++ b/vendor/plugins/sfu_test_cluster/init.rb
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2011 Instructure, Inc.
+#
+# This file is part of Canvas.
+#
+# Canvas is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License as published by the Free
+# Software Foundation, version 3 of the License.
+#
+# Canvas is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# SFU Note: Slightly modified from the original provided by ccutrer in IRC.
+#           Original file can be found at https://gist.github.com/grahamb/ed5475ac5f4cbbacf62b
+
+ApplicationController.class_eval do
+  def self.test_cluster
+    unless defined?(@test_cluster)
+      @test_cluster = Setting.from_config('testcluster', false).try(:[], 'test_cluster')
+    end
+    @test_cluster
+  end
+
+  def self.test_cluster?
+    !!self.test_cluster
+  end
+
+  before_filter :add_tc_warning
+  def add_tc_warning
+    return true unless ApplicationController.test_cluster?
+    @fixed_warnings ||= []
+    @fixed_warnings << {
+      :icon => "warning",
+      :title => t('#warnings.test_install.title', "Canvas Test Installation"),
+      :message => t('#warnings.test_install.message', "This Canvas installation is only for testing, and may be reset at any time without warning."),
+    }
+  end
+
+  before_filter :block_student_access
+  def block_student_access
+    return true unless ApplicationController.test_cluster?
+    return true if @files_domain
+    return true if @real_current_user # masquerading is always allowed
+    return true if self.is_a? InfoController and params[:action] == 'health_check'
+    # teachers need to be able to accept invitations
+    return true if self.is_a? CoursesController and params[:action] == 'enrollment_invitation'
+
+    return true unless @domain_root_account # WTF? apparently mobile verify skips loading the DRA
+    return true if @domain_root_account.service_enabled?(:beta_for_students) # account setting to be nice
+    old_crumbs = crumbs.dup
+    get_context rescue nil
+    # avoid double-crumbs cause we nil out @context and it gets called again
+    crumbs.replace(old_crumbs)
+    if @context.is_a?(Course) && !@context.grants_right?(@current_user, :read_as_admin)
+      @unauthorized_message = "Students are not allowed to access test installations."
+      return render_unauthorized_action
+    end
+    @context = nil
+  end
+end


### PR DESCRIPTION
This plugin displays a "test system" warning and prevents accounts with student roles from accessing courses on non-production systems (for which the plugin has been enabled). Code was provided by Instructure and slightly modified as it contained some multi-tenant specific stuff that we don't need.

When enabled, if an account with a student role tries to access a page within a course, they will receive a message stating that "students are not allowed to access test installations." The warning does not appear on the course's index page, but does for anything else inside a course (including files).

Enabling the plugin is a matter of having a testcluster.yml file in the config directory. The plugin looks for a "test_cluster" property; if the value is truthy then the plugin is enabled. testcluster.yml.(prod,stage,test,edge) files are in place in the /usr/local/canvas shared mount point already. .prod is false, everything else is true.

**TEST PLAN:**
- enable the plugin (add testcluster.yml to canvas/config -> "test_cluster: true")
- log in as yourself
  - verify that red bar appears at bottom of page
  - verify that you can access everything as an admin
- log in as an instructor
  - verify that red bar appears at bottom of page
  - verify that you can access the instructor's course(s) normally
- log in as a student
  - verify that red bar appears at bottom of page
  - verify that you CAN NOT access items within a course
