### PR TITLE
Override sfu_stats api_request? to force api calls to use authentication

### DIFF
--- a/vendor/plugins/sfu_stats/app/controllers/stats_controller.rb
+++ b/vendor/plugins/sfu_stats/app/controllers/stats_controller.rb
@@ -1,4 +1,5 @@
 class StatsController < ApplicationController
+  include Common
   before_filter :require_user
   def index
     @current_term = current_term

--- a/vendor/plugins/sfu_stats/app/helpers/common.rb
+++ b/vendor/plugins/sfu_stats/app/helpers/common.rb
@@ -1,0 +1,8 @@
+module Common
+
+  # orverride ApplicationController::api_request? to force canvas to treat all calls to /sfu/api/* as an API call
+  def api_request?
+    return true
+  end
+
+end


### PR DESCRIPTION
Uses the same trick as sfu_api to force `api_request?` to return true. Needed to be able to pull the stats via HTTP from outside Canvas (e.g. from a dashboard).

(Note: edited the pull subject and body to reference the correct method name)
