### PR TITLE
add fix for new conversations toolbar appearing under rainbow bar

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -100,7 +100,6 @@
     }
     // END no-flash upload FIX
 
-    // Fix top positioning on the conversations page
     // Fix for the new conversations page - toolbar renders underneath the rainbow bar
     utils.onPage(/conversations/, function() {
         // are we on the new conversations page?


### PR DESCRIPTION
The toolbar for the new conversations view appears under the SFU rainbow bar as it has a fixed top property. Uses custom JS to bump it down on page load.

Also adds a bunch of utility functions to sfu.js (on the `utils` namespace). Taken from rpflorence's InstructureCon presentation: https://gist.github.com/rpflorence/5817898
