### PR TITLE
Make Course form compatible with Backbone 1.0.0

### DIFF
--- a/vendor/plugins/sfu_course_form/app/coffeescripts/collections/CourseList.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/collections/CourseList.coffee
@@ -8,13 +8,9 @@ define [
   class CourseList extends Backbone.Collection
 
     initialize: (@term) ->
-      @on 'reset', ->
+      @on 'sync', ->
         @each ( (course) -> course.term = @term ), this
       super
-
-    fetch: (options) ->
-      @trigger 'request'
-      Backbone.Collection.prototype.fetch.call(this, options)
 
     model: Course
 

--- a/vendor/plugins/sfu_course_form/app/coffeescripts/collections/SandboxList.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/collections/SandboxList.coffee
@@ -8,8 +8,4 @@ define [
 
     initialize: (@userId) -> super
 
-    fetch: (options) ->
-      @trigger 'request'
-      Backbone.Collection.prototype.fetch.call(this, options)
-
     url: -> "/sfu/api/v1/user/#{@userId}/sandbox"

--- a/vendor/plugins/sfu_course_form/app/coffeescripts/views/courses/CourseListView.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/views/courses/CourseListView.coffee
@@ -9,7 +9,7 @@ define [
 
     initialize: ->
       @collection.on 'request', ( -> this.$el.html '<li>Loading&hellip;</li>' ), this
-      @collection.on 'reset', ( -> @render() ), this
+      @collection.on 'sync', ( -> @render() ), this
       @collection.on 'error', ( -> this.$el.html '<li>No available courses</li>' ), this
       super
 

--- a/vendor/plugins/sfu_course_form/app/coffeescripts/views/sandboxes/SandboxListView.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/views/sandboxes/SandboxListView.coffee
@@ -8,7 +8,7 @@ define [
 
     initialize: ->
       @collection.on 'request', ( -> this.$el.html '<p>Loading existing sandbox courses&hellip;</p>' ), this
-      @collection.on 'reset', ( -> @render() ), this
+      @collection.on 'sync', ( -> @render() ), this
       super
 
     tagName: 'div'


### PR DESCRIPTION
Instructure updated Backbone from 0.9.2 to 1.0.0, and that broke our Start a New Course form. We were listening to an event that is no longer being triggered (`reset`), which caused the perpetual "Loading..." problem.

This patch addresses these Backbone changes:
- In Backbone 0.9.9, the `request` event was added to `Backbone.sync`, so the `Collection#fetch` override to trigger `request` is no longer needed.
- In Backbone 1.0.0, the default updating mechanism after a fetch no longer triggers `reset`. Use the `sync` event instead.
