### PR TITLE
Change help link in header to a dropdown

### DIFF
--- a/public/sfu/css/sfu.css
+++ b/public/sfu/css/sfu.css
@@ -25,7 +25,7 @@
 }
 
 .with-right-side #header-inner, #header-inner {
-    max-width: 100%;
+    max-width: 100% !important;
 }
 
 #identity {
@@ -34,6 +34,17 @@
     border: none;
     box-shadow: none;
     font-family: "DINProRegular", "Helvetica Neue", Arial, "Liberation Sans", FreeSans, sans-serif;;
+}
+
+/* Help Link Dropdown */
+
+.sfu_help_links {
+    width: auto;
+    height: auto;
+    font-size: 12px;
+    margin-bottom: auto;
+    position: relative;
+    top: -3px;
 }
 
 #menu {

--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -37,9 +37,25 @@
 
 
     // header rainbow
-
     $('#header').append('<div id="header-rainbow">');
-    $('#topbar .logout').before('<li><a href="http://www.sfu.ca/canvas" target=_blank>Help</a></li>')
+
+    // help links
+    var helpHtml = [
+        '<li>',
+        '<select class="sfu_help_links">',
+        '<option value="">Help</option>',
+        '<option value="https://canvas.sfu.ca/courses/14504">Help for Students</option>',
+        '<option value="https://canvas.sfu.ca/courses/14504">Help for Instructors</option>',
+        '</li>'
+    ].join('');
+    $('#topbar .logout').before(helpHtml);
+    $('#topbar .sfu_help_links').on('change', function(ev) {
+        if (this.value) {
+            window.location = this.value;
+        }
+    });
+
+    // sfu logo in footer
     $('footer').html('<a href="http://www.sfu.ca/canvas"><img alt="SFU Canvas" src="/sfu/images/sfu-logo.png" width="250" height="38"></a>').show();
 
     // handle no-user case


### PR DESCRIPTION
Per TLC request - they've created Instructor and Student Help shells in Canvas.

Looks fine in Chrome and Safari. Looks a bit goofy in Firefox and IE, but servicable. You can't reliably style `<select>` elements so this is as good as its going to get without spending more time than it's worth on it.

 I threw an IE 7 screenshot in there; even though it isn't supported and users get a warning when the log in, it's still the 3rd most popular version of IE according to our stats (16th overall).

Chrome:
![chrome](https://f.cloud.github.com/assets/146111/1853588/8b838344-770e-11e3-84fe-7f5690eb22b8.png)

Firefox:
![firefox](https://f.cloud.github.com/assets/146111/1853589/8b83adce-770e-11e3-9029-1096391e350a.png)

Safari:
![safari](https://f.cloud.github.com/assets/146111/1853593/8b890b66-770e-11e3-8b75-2a5b0f1dc2cf.png)

IE 10:
![ie 10](https://f.cloud.github.com/assets/146111/1853592/8b887e94-770e-11e3-82ec-ec9de5aa0e2f.png)

IE 9:
![ie 9](https://f.cloud.github.com/assets/146111/1853591/8b85eb48-770e-11e3-90d9-d745725e13f4.png)

IE 7:
![ie 7](https://f.cloud.github.com/assets/146111/1853590/8b841d04-770e-11e3-8f3f-4670b85a04bf.png)
