### PR TITLE
Fix broken sorting in Gradebook (SIS ID column)

### DIFF
--- a/app/coffeescripts/gradebook2/Gradebook.coffee
+++ b/app/coffeescripts/gradebook2/Gradebook.coffee
@@ -967,11 +967,13 @@ define [
       $('body').on('click', @onGridBlur)
 
       @grid.onSort.subscribe (event, data) =>
-        if data.sortCol.field == "display_name" || data.sortCol.field == "secondary_identifier"
+        # SFU MOD CANVAS-188 Make SIS ID column sortable
+        if data.sortCol.field == "display_name" || data.sortCol.field == "secondary_identifier" || data.sortCol.field == "sis_id"
+        # END SFU MOD
           sortProp = if data.sortCol.field == "display_name"
             "sortable_name"
           else
-            "secondary_identifier"
+            data.sortCol.field # SFU MOD - CANVAS-188 Make SIS ID column sortable
           @sortRowsBy (a, b) =>
             [b, a] = [a, b] if not data.sortAsc
             @localeSort(a[sortProp], b[sortProp])


### PR DESCRIPTION
This addresses another change in the Gradebook from the 2014-01-18 release, in which comprehensive locale-aware sorting was added (https://github.com/instructure/canvas-lms/commit/a51385bc02edcaf5540a85825abd547af485c70c).
