### PR TITLE
Remove old code in Gradebook.coffee

### DIFF
--- a/app/coffeescripts/gradebook2/Gradebook.coffee
+++ b/app/coffeescripts/gradebook2/Gradebook.coffee
@@ -1012,22 +1012,6 @@ define [
         student.row = i
         @addDroppedClass(student)
       @grid.invalidate()
-      @grid.onSort.subscribe (event, data) =>
-        sortRowsBy (a, b) ->
-          aScore = a[data.sortCol.field]?.score
-          bScore = b[data.sortCol.field]?.score
-          aScore = -99999999999 if not aScore and aScore != 0
-          bScore = -99999999999 if not bScore and bScore != 0
-          if data.sortAsc then bScore - aScore else aScore - bScore
-      @grid.onSort.subscribe (event, data) =>
-        # SFU MOD CANVAS-188 Make SIS ID column sortable
-        propertyToSortBy = {display_name: 'sortable_name', secondary_identifier: 'secondary_identifier', sis_id: 'sis_id'}[data.sortCol.field]
-        # END SFU MOD
-        sortRowsBy (a, b) ->
-          res = if a[propertyToSortBy] < b[propertyToSortBy] then -1
-          else if a[propertyToSortBy] > b[propertyToSortBy] then 1
-          else 0
-          if data.sortAsc then res else 0 - res
 
     localeSort: (a, b) =>
       a.localeCompare b,


### PR DESCRIPTION
The removed code was first removed here: https://github.com/instructure/canvas-lms/commit/a51385bc02edcaf5540a85825abd547af485c70c, but was inadvertently added back in when we pulled in the 2014-01-18 release. My apologies for missing this in the first place.

Our version of `Gradebook.coffee` should now differ from Instructure's version **only** by changes marked with or wrapped around **`SFU MOD`** markers.
