### PR TITLE
Modify the test cluster plugin to allow whitelisted users to bypass the student lockout

### DIFF
--- a/vendor/plugins/sfu_api/app/model/sfu/rest.rb
+++ b/vendor/plugins/sfu_api/app/model/sfu/rest.rb
@@ -27,14 +27,22 @@ module SFU
       "#{rest_server}/rest/course/course.js"
     end
 
+    def maillist_membership_url
+      "#{rest_server}/rest/maillist/members.js"
+    end
+
     def canvas_sis_import_url
       account_id = Account.find_by_name("Simon Fraser University").id
       "#{canvas_server}/api/v1/accounts/#{account_id}/sis_imports.json?extension=csv"
     end
 
+    def text(url, params)
+      rest_url = "#{url}?art=#{sfu_rest_token}#{params}"
+      RestClient.get rest_url
+    end
+
     def json(url, params)
       rest_url = "#{url}?art=#{sfu_rest_token}#{params}"
-
       begin
         json_out = RestClient.get rest_url
         JSON.parse json_out

--- a/vendor/plugins/sfu_api/app/model/sfu/sfu.rb
+++ b/vendor/plugins/sfu_api/app/model/sfu/sfu.rb
@@ -79,6 +79,12 @@ module SFU
       def info(sfuid)
         REST.json(REST.account_url, "&username=#{sfuid}")
       end
+
+      def belongs_to_maillist?(username, maillist)
+        membership = REST.text(REST.maillist_membership_url, "&address=#{username}&listname=#{maillist}")
+        !(membership == '""')
+      end
+
     end
   end
 


### PR DESCRIPTION
Modifications to both the sfu_api and test_cluster plugins to allow whitelisted users to bypass the student lockout.

The whitelist is a SFU maillist: canvas-test-cluster-bypass. It's currently owned by me but it should be handed off to someone else, probably within the TLC.

This code (along with a current database) is installed on icat-graham-canvas.its.sfu.ca. Test steps below; when logging in as someone else, use the yourusername:theirusername CAS feature, not the built-in impersonation.
- Log in as yourself (an admin user). You should still have full access to everything.
- Log in as an instructor. You should still have full access to everything inside a course (matches `@context.grants_right?(@current_user, :read_as_admin)`).
- Log in as a student who is not a member of canvas-test-cluster-bypass. You should be able to get to the "front page" of a course, but no further inside the course (matches neither `@context.grants_right?(@current_user, :read_as_admin)` or `SFU::User.belongs_to_maillist?(current_username, "canvas-test-cluster-bypass")`).
- Add the student to the canvas-test-cluster-bypass list and try again. You should not be able to access previously-restricted pages inside the course (matches `SFU::User.belongs_to_maillist?(current_username, "canvas-test-cluster-bypass")`).
