### PR TITLE
Fix inability to re-create deleted course

### DIFF
--- a/vendor/plugins/sfu_api/app/controllers/api_controller.rb
+++ b/vendor/plugins/sfu_api/app/controllers/api_controller.rb
@@ -141,7 +141,7 @@ class ApiController < ApplicationController
   end
 
   def course_info(sis_id, property = nil)
-    course = Course.where(:sis_source_id => sis_id.downcase).all
+    course = Course.active.where(:sis_source_id => sis_id.downcase).all
     if course.empty?
       raise(ActiveRecord::RecordNotFound)
     end


### PR DESCRIPTION
The API was including deleted courses before, so the form was stopping anyone from re-creating a deleted course with the same SIS ID (via the Start a New Course form). This fix excludes deleted courses.
