### PR TITLE
Fix broken sorting in Gradebook (SIS ID column)

### DIFF
--- a/app/coffeescripts/gradebook2/Gradebook.coffee
+++ b/app/coffeescripts/gradebook2/Gradebook.coffee
@@ -1037,8 +1037,8 @@ define [
       @grid.onSort.subscribe (event, data) =>
         if data.sortCol.field == "display_name" ||
            data.sortCol.field == "secondary_identifier" ||
-           data.sortCol.field.match /^custom_col/  ||
-           data.sortCol.field == "sis_id" # SFU MOD - CANVAS-188 Make SIS ID sortable
+           data.sortCol.field == "sis_id" || # SFU MOD - CANVAS-188 Make SIS ID sortable
+           data.sortCol.field.match /^custom_col/
           sortProp = if data.sortCol.field == "display_name"
             "sortable_name"
           else


### PR DESCRIPTION
Swap the order so the `sis_id` line does not get included in the previous line inside the `.match()` method when the CoffeeScript compiled into JS.

This is what happened before:

``` js
b.sortCol.field.match(/^custom_col/ || b.sortCol.field === "sis_id")
```

And this is what we want (order doesn't matter):

``` js
b.sortCol.field.match(/^custom_col/) || b.sortCol.field === "sis_id"
```

See related history:
- https://github.com/sfu/canvas-lms/commit/4ec07910f0ae9625c794eccbae5dd0c217f2b392
- https://github.com/sfu/canvas-lms/commit/4e19700bcd3c26600009f783fc8d1ecaa42fc522
