### PR TITLE
add message_user_path to the sfu profile endpoint

### DIFF
--- a/vendor/plugins/sfu_api/app/controllers/api_controller.rb
+++ b/vendor/plugins/sfu_api/app/controllers/api_controller.rb
@@ -23,9 +23,9 @@ class ApiController < ApplicationController
     account_id = Account.find_by_name('Simon Fraser University').id
     sfu_id = params[:sfu_id]
     pseudonym = Pseudonym.where(:unique_id => sfu_id, :account_id => account_id).all
-    
+
     raise(ActiveRecord::RecordNotFound) if pseudonym.empty?
-    
+
     user_hash = {}
     unless pseudonym.empty?
       user = User.find pseudonym.first.user_id
@@ -39,6 +39,7 @@ class ApiController < ApplicationController
         user_hash["id"] = user.id
         user_hash["name"] = user.name
         user_hash["uuid"] = user.uuid
+        user_hash["message_user_path"] = message_user_path(user)
       elsif params[:property].eql? "groups"
         user_hash = group_membership_for user
       elsif params[:property].eql? "mysfu"


### PR DESCRIPTION
message_user_path(user) returns a path that, when followed, opens the message UI and creates a new message addressed to the destination user. For example, https://canvas.sfu.ca/conversations#7b22757365725f6964223a31322c22757365725f6e616d65223a2247726168616d2042616c6c616e74796e65222c22636f6e746578745f6964223a6e756c6c7d will address a new message to me.

I want to allow a user to send a message to an instructor via the course outlines LTI. There doesn't appear to be a Canvas API method to return the message_user_path so I've added it to the SFU profile API.
