### PR TITLE
Retire file uploader fix for Flashless browsers

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -103,19 +103,6 @@
 
     // END CANVAS-192
 
-    // FIX (temporary) for no-flash browsers to upload files using the Files tool
-    var hasFlash = false;
-    try {
-        if (new ActiveXObject('ShockwaveFlash.ShockwaveFlash')) hasFlash = true;
-    } catch(e) {
-        if (navigator.mimeTypes ["application/x-shockwave-flash"] != undefined) hasFlash = true;
-    }
-    if (!hasFlash) {
-        // remove the invisible element that is blocking the "Add File" link
-        $('#swfupload_holder').hide();
-    }
-    // END no-flash upload FIX
-
     // Add copyright compliance notice under the Publish Course button
     utils.onPage(/^\/courses\/\d+$/, function() {
         // The Publish Course button ID attribute contains the course ID


### PR DESCRIPTION
The bug was fixed in the core Canvas code as of the 5/3/14 release: https://github.com/instructure/canvas-lms/commit/7cf4c8f58c218269f254c86a4a32d00ef5c2ce37
