### PR TITLE
remove Grades, Syllabus and Library Reserves from collab space nav

### DIFF
--- a/public/sfu/css/collab_space.css
+++ b/public/sfu/css/collab_space.css
@@ -5,3 +5,9 @@
 #wiki_edit_view_main #below_editor div:nth-child(-n+2) {
     display: none;
 }
+
+li.section > a.grades,
+li.section > a.syllabus,
+li.section > a.context_external_tool_159 {
+    display: none;
+}


### PR DESCRIPTION
@va7map and I figured this was much easier than having him have to wait until the course was created and then try to disable undesirable features via the API. I initially tried this with JavaScript (loop through the nav elements, remove ones with matching text) but you would initially see the items on page load until the script ran.

The only downside to doing it this way in CSS is that the Library Reserves item has a stupid class name (.context_external_tool_159). If we ever remove and re-add the LTI, it'll get a new ID number and its class will change. The chances of that happening would be fairly slim, I would think.
