### PR TITLE
Hide the Start a New Ad Hoc Space button

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -149,6 +149,7 @@
     utils.onPage(/^\/(courses)?$/, function () {
         // Add the button right after the existing Start a New Course button
         var addAdHocButton = function () {
+            return; // TODO: Remove this line when Ad Hoc Spaces are ready
             var $courseButton = $('#start_new_course');
             var $adhocButton = $courseButton.clone();
             $adhocButton


### PR DESCRIPTION
We should pull this in **before the upgrade on June 13, 2014**. Ad hoc spaces are not ready yet.
