### PR TITLE
Fix course copy migration regression

### DIFF
--- a/vendor/plugins/sfu_course_copy_importer/init.rb
+++ b/vendor/plugins/sfu_course_copy_importer/init.rb
@@ -14,7 +14,8 @@ Rails.configuration.to_prepare do
           :requires_file_upload => false,
           :skip_conversion_step => true,
           :required_options_validator => Canvas::Migration::Validators::CourseCopyValidator,
-          :required_settings => [:source_course_id]
+          :required_settings => [:source_course_id],
+          :valid_contexts => %w{Course}
       },
   }
 end


### PR DESCRIPTION
The regression prevented users from importing courses using our version of the plugin. It was introduced in f84003358f5467cc3cae9b7c409c045727559f5b when the migrations controller started checking for valid contexts. This fix is based on 2ba4531f730a366c9f2b0af1c6a38ccd7dc356df (`default_plugins.rb#L140-141`).
