### PR TITLE
Fix copyright compliance notice compatibility

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -103,21 +103,30 @@
 
     // END CANVAS-192
 
-    // Add copyright compliance notice under the Publish Course button
+    // Add copyright compliance notice
     utils.onPage(/^\/courses\/\d+$/, function() {
-        // The Publish Course button ID attribute contains the course ID
-        var $publishButton = $('#' + location.pathname.replace('/courses/', 'edit_course_'));
+        // The Publish Course form ID attribute contains the course ID
+        var publishFormId = location.pathname.replace('/courses/', 'edit_course_');
+        var noticeHtml = "<p>I confirm that the use of copyright protected materials in this course complies with Canada's <em>Copyright Act</em> and SFU Policy R30.04 - <em>Copyright Compliance and Administration</em>. </p>";
+
+        // Add it directly under the Publish Course button in the wizard
+        var $wizardPublishButton = $('#wizard_box #' + publishFormId);
         var $readMoreLink = $('<a href="/sfu/copyright/disclaimer" class="element_toggler" aria-controls="copyright_dialog" target="_blank">Read more.</a>');
         var $disclaimer = $('<iframe src="/sfu/copyright/disclaimer" seamless="seamless" width="100%" height="100%">').css('border', 'none');
-        $("<p>I confirm that the use of copyright protected materials in this course complies with Canada's <em>Copyright Act</em> and SFU Policy R30.04 - <em>Copyright Compliance and Administration</em>. </p>")
+        $(noticeHtml)
             .append($readMoreLink)
-            .insertAfter($publishButton);
+            .insertAfter($wizardPublishButton);
         // Use a modal dialog to display the full disclaimer
         $('<form id="copyright_dialog" title="Copyright Disclaimer">')
             .attr('data-turn-into-dialog', '{"width":600,"height":500,"modal":true}')
             .append($disclaimer)
             .hide()
             .appendTo('body');
+
+        // Show it in a dialog when the Publish button in the sidebar is clicked (abort publish if user hits Cancel)
+        $('#' + publishFormId + ' button.btn-publish').on('click', function () {
+            if (!confirm($(noticeHtml).text())) { return false; }
+        });
     });
 
     // Fixes for Import Content page only


### PR DESCRIPTION
In the 7/12/14 release, a new Publish button was added to the right sidebar. This allows users to publish a course directly, therefore bypassing the original copyright compliance notice placed under the old Publish Course button.

With this fix, when users click the new Publish button, a confirmation dialog containing the notice will display.
