### PR TITLE
Fix copyright survey random query + simplify routes (Rails 2/3)

### DIFF
--- a/vendor/plugins/sfu_copyright/app/controllers/copyright_api_controller.rb
+++ b/vendor/plugins/sfu_copyright/app/controllers/copyright_api_controller.rb
@@ -27,8 +27,8 @@ class CopyrightApiController < ApplicationController
     end
 
     # Randomly select a course and instructor
-    course = courses.rand
-    teacher = course.teachers.rand
+    course = courses.first(:order => 'RANDOM()')
+    teacher = course.teachers.first(:order => 'RANDOM()')
 
     # Determine the SFU Computing ID and email address of the instructor
     # NOTE: The course could (very rarely) be teacher-less

--- a/vendor/plugins/sfu_copyright/config/routes.rb
+++ b/vendor/plugins/sfu_copyright/config/routes.rb
@@ -1,7 +1,4 @@
 (CANVAS_RAILS2 ? FakeRails3Routes : CanvasRails::Application.routes).draw do
   match "/sfu/copyright/disclaimer" => "copyright#disclaimer"
-end
-
-(CANVAS_RAILS2 ? FakeRails3Routes : CanvasRails::Application.routes).draw do
   match "/sfu/api/v1/copyright/random/:term" => "copyright_api#random_course_files", :defaults => { :format => "json" }
 end


### PR DESCRIPTION
Rails 3 uses ActiveRecord::Relation, which doesn't have a public `rand` method. This alternative works on both Rails 2 and 3.

Also, I simplified and tested the routes file.
