### PR TITLE
add q&a forum link to help dropdown

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -45,7 +45,7 @@
         '<select class="sfu_help_links">',
         '<option value="">Help</option>',
         '<option value="https://canvas.sfu.ca/courses/14504">Help for Students</option>',
-        '<option value="https://canvas.sfu.ca/courses/14504">Help for Students</option>',
+        '<option value="https://canvas.sfu.ca/courses/14686">Help for Instructors</option>',
         '<option value="http://www.sfu.ca/techforum">Q&A Forum</option>',
         '</li>'
     ].join('');


### PR DESCRIPTION
TLC request via Keith to add a Q&A Forum link (www.sfu.ca/techforum) to the Help dropdown. Need to bring this in for this week's deploy.
