### PR TITLE
Fix existing sandbox list in Start a New Course form

### DIFF
--- a/vendor/plugins/sfu_api/app/controllers/api_controller.rb
+++ b/vendor/plugins/sfu_api/app/controllers/api_controller.rb
@@ -206,7 +206,7 @@ class ApiController < ApplicationController
 
   def sandbox_for(user)
     # Find user's courses with sis_source_id that starts with 'sandbox'
-    courses = Course.find(:all, :conditions => ['id IN (?) AND sis_source_id LIKE ?', user.course_ids, 'sandbox%'])
+    courses = Course.find(:all, :conditions => ['id IN (?) AND sis_source_id LIKE ?', user.courses.map(&:id), 'sandbox%'])
     courses.map do |course|
       {
         :id => course.id,


### PR DESCRIPTION
The User model was recently refactored to use scopes instead of associations with joins (see [related commit](https://github.com/instructure/canvas-lms/commit/57f6ef2d7d9817f19b080ec6a845b5fb2800c8b0#diff-4676c008b11a5480d73d4a6de01e45b9L82)). That change eliminated the `User#course_ids` method, and caused the Start a New Course form to not display any existing sandbox courses.

The fix is to use the new `User#courses` method to get the course IDs.
