### PR TITLE
Replace Google Docs Preview with Predoc in new UI

### DIFF
--- a/app/controllers/file_previews_controller.rb
+++ b/app/controllers/file_previews_controller.rb
@@ -72,7 +72,9 @@ class FilePreviewsController < ApplicationController
         redirect_to url and return
       # google docs
       elsif service_enabled?(:google_docs_previews) && GOOGLE_PREVIEWABLE_TYPES.include?(@file.content_type)
-        redirect_to('//docs.google.com/viewer?' + { embedded: true, url: @file.authenticated_s3_url }.to_query) and return
+        # SFU MOD CANVAS-205 Predoc: In-place Replacement for Google Docs Preview
+        redirect_to('//docview.sfu.ca/viewer?' + { embedded: true, url: @file.authenticated_s3_url }.to_query) and return
+        # END SFU MOD
       # images
       elsif @file.content_type =~ %r{\Aimage/}
         return render template: 'file_previews/img_preview', layout: false

--- a/spec/controllers/file_previews_controller_spec.rb
+++ b/spec/controllers/file_previews_controller_spec.rb
@@ -74,7 +74,7 @@ describe FilePreviewsController do
     attachment_model content_type: 'application/msword'
     get :show, course_id: @course.id, file_id: @attachment.id
     expect(response).to be_redirect
-    expect(response.location).to match %r{\A//docs.google.com/viewer}
+    expect(response.location).to match %r{\A//docview.sfu.ca/viewer} # SFU MOD - CANVAS-205
   end
 
   it "should render a download link if no previews are available" do


### PR DESCRIPTION
Re-apply the mod to the new `FilePreviewsController` so it uses Predoc instead of Google Docs to preview files. This new controller is used by the Files page if the "Better File Browsing" feature option is enabled.

Related to CANVAS-205