### PR TITLE
Fix PIA/Copyright Notices

### DIFF
--- a/public/sfu/css/sfu.css
+++ b/public/sfu/css/sfu.css
@@ -140,10 +140,13 @@
 /* !-- PIA notice styles -- */
 
 .pia-notice {
-    margin: 2em 0;
     padding: 1em 1.5em;
     border: 1px solid #CCC;
     background: #EFEFEF;
+}
+
+#google_docs_description .pia-notice {
+    margin: 2em 0;
 }
 
 .pia-notice hr {

--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -108,25 +108,20 @@
     utils.onPage(/^\/courses\/\d+$/, function() {
         // The Publish Course form ID attribute contains the course ID
         var publishFormId = location.pathname.replace('/courses/', 'edit_course_');
-        var noticeHtml = "<p>I confirm that the use of copyright protected materials in this course complies with Canada's <em>Copyright Act</em> and SFU Policy R30.04 - <em>Copyright Compliance and Administration</em>. </p>";
 
-        // Add it directly under the Publish Course button in the wizard
-        var $wizardPublishButton = $('#wizard_box #' + publishFormId);
-        var $readMoreLink = $('<a href="/sfu/copyright/disclaimer" class="element_toggler" aria-controls="copyright_dialog" target="_blank">Read more.</a>');
-        var $disclaimer = $('<iframe src="/sfu/copyright/disclaimer" seamless="seamless" width="100%" height="100%">').css('border', 'none');
-        $(noticeHtml)
-            .append($readMoreLink)
-            .insertAfter($wizardPublishButton);
-        // Use a modal dialog to display the full disclaimer
-        $('<form id="copyright_dialog" title="Copyright Disclaimer">')
-            .attr('data-turn-into-dialog', '{"width":600,"height":500,"modal":true}')
-            .append($disclaimer)
-            .hide()
-            .appendTo('body');
+        var confirmCopyright = function () {
+            return confirm("I confirm that the use of copyright protected materials in this course complies with" +
+                "Canada's Copyright Act and SFU Policy R30.04 - Copyright Compliance and Administration.");
+        };
 
-        // Show it in a dialog when the Publish button in the sidebar is clicked (abort publish if user hits Cancel)
+        // Show the notice in a confirmation dialog when the user clicks the Publish button in the sidebar or in the
+        // Setup Checklist (a.k.a. Course Wizard). Abort if user hits Cancel.
         $('#' + publishFormId + ' button.btn-publish').on('click', function () {
-            if (!confirm($(noticeHtml).text())) { return false; }
+            return confirmCopyright();
+        });
+        // NOTE: This assumes only the Publish the Course button uses a POST form in the Course Wizard.
+        $(document).on('submit', '.CourseWizard__modalOverlay form[method="post"]', function () {
+            return confirmCopyright();
         });
     });
 

--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -161,38 +161,22 @@
             'before using External Learning and Collaboration Tools such as Google Docs because they may disclose and ' +
             'store your personal information elsewhere inside and outside Canada.</p>');
     });
-    utils.onPage(/^\/courses\/\d+\/settings\/?$/, function () {
-        var addedAppCenterNotice = false;
-        var addAppCenterNotice = function () {
-            if (addedAppCenterNotice) { return; } // only add it once
-            addedAppCenterNotice = true;
-            $('<div class="pia-notice">')
-                .insertBefore('#app_center_filter_wrapper')
-                .append('<p><strong>Is your app privacy compliant?</strong> There are <strong>personal legal ' +
-                    'consequences</strong> if you use an app that discloses and stores students&rsquo; personal ' +
-                    'information elsewhere inside or outside Canada without their consent. Unauthorized disclosure ' +
-                    'is a privacy protection offense under BC law. Employees and SFU are liable to investigation and ' +
-                    'possible fines. <strong>Before using any app</strong>, carefully review the complete ' +
-                    '<a href="http://www.sfu.ca/canvasprivacynotice" target="_blank">Canvas Privacy Protection Notice</a> ' +
-                    'to <strong>understand your legal responsibilities</strong> and please contact ' +
-                    '<a href="mailto:learntech@sfu.ca">learntech@sfu.ca</a>. The Learning Technology Specialists in the ' +
-                    '<strong>Teaching and Learning Centre will help you</strong> complete an app privacy assessment ' +
-                    'and, if needed, advise you how to obtain students&rsquo; consent in the manner prescribed by law. ' +
-                    'By using apps in your course and the App Centre in Canvas, you acknowledge that you <strong>read ' +
-                    'the Privacy Protection Notice</strong> and will <strong>follow the described protection of privacy ' +
-                    'requirements and procedure</strong>.</p>');
-        };
-
-        // If App Center content is not present, wait for external tools to load before adding the notice.
-        if ($('#app_center_filter_wrapper').length == 0) {
-            $(document).ajaxComplete(function (event, XMLHttpRequest, ajaxOptions) {
-                if (ajaxOptions.url && ajaxOptions.url.match(/api\/v1\/courses\/\d+\/external_tools/)) {
-                    addAppCenterNotice();
-                }
-            });
-        } else {
-            addAppCenterNotice();
-        }
+    utils.onPage(/^\/courses\/\d+\/settings/, function () {
+        $('<div class="pia-notice">')
+            .insertBefore('#external_tools')
+            .append('<p><strong>Is your app privacy compliant?</strong> There are <strong>personal legal ' +
+                'consequences</strong> if you use an app that discloses and stores students&rsquo; personal ' +
+                'information elsewhere inside or outside Canada without their consent. Unauthorized disclosure ' +
+                'is a privacy protection offense under BC law. Employees and SFU are liable to investigation and ' +
+                'possible fines. <strong>Before using any app</strong>, carefully review the complete ' +
+                '<a href="http://www.sfu.ca/canvasprivacynotice" target="_blank">Canvas Privacy Protection Notice</a> ' +
+                'to <strong>understand your legal responsibilities</strong> and please contact ' +
+                '<a href="mailto:learntech@sfu.ca">learntech@sfu.ca</a>. The Learning Technology Specialists in the ' +
+                '<strong>Teaching and Learning Centre will help you</strong> complete an app privacy assessment ' +
+                'and, if needed, advise you how to obtain students&rsquo; consent in the manner prescribed by law. ' +
+                'By using apps in your course and the App Centre in Canvas, you acknowledge that you <strong>read ' +
+                'the Privacy Protection Notice</strong> and will <strong>follow the described protection of privacy ' +
+                'requirements and procedure</strong>.</p>');
     });
 
     // Fixes for Import Content page only


### PR DESCRIPTION
The 2015-01-31 release introduced the use of React to render Course Wizard and External Apps (among other things) dynamically. Any changes we insert are overwritten whenever the components re-renders. This makes it very difficult to inject content inside React components.

We react by intercepting specific form submissions and displaying the notice elsewhere.