### PR TITLE
Vagrant: move bundler version to a variable

### DIFF
--- a/provision/gems/tasks/bundler.yml
+++ b/provision/gems/tasks/bundler.yml
@@ -1,3 +1,3 @@
 - name: Install bundler gem
   sudo: yes
-  shell: gem install bundler --version=1.6.0 --no-ri --no-rdoc
+  shell: gem install bundler --version={{bundler_version}} --no-ri --no-rdoc

--- a/provision/vagrant.yml
+++ b/provision/vagrant.yml
@@ -1,6 +1,7 @@
 - hosts: all
   sudo: true
   vars:
+    bundler_version: 1.7.11
     canvas_account_name: Simon Fraser University
     canvas_admin_email: vagrant@localhost
     canvas_admin_password: vagrant


### PR DESCRIPTION
The bundler version required by Canvas changes from time-to-time. Previously this was hard-coded into the bundler provisioner file. I've moved it out to a variable so that it can more easily updated.

Ideally I'll come up with a way of automagically installing the right version when the bundler provisioner runs, but this is better than current state.