### PR TITLE
Downgrade SFUCopyrightCompliance components to old react

### DIFF
--- a/app/jsx/sfu_copyright_compliance_notice/SFUCopyrightComplianceNotice.jsx
+++ b/app/jsx/sfu_copyright_compliance_notice/SFUCopyrightComplianceNotice.jsx
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 define([
-  'react',
+  'old_unsupported_dont_use_react',
   './SFUCopyrightComplianceNoticeMoreInfo'
   ], function (React, SFUCopyrightComplianceNoticeMoreInfo) {
 

--- a/app/jsx/sfu_copyright_compliance_notice/SFUCopyrightComplianceNoticeModalDialog.jsx
+++ b/app/jsx/sfu_copyright_compliance_notice/SFUCopyrightComplianceNoticeModalDialog.jsx
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 define([
-  'react',
-  'react-modal',
+  'old_unsupported_dont_use_react',
+  'old_unsupported_dont_use_react-modal',
   './SFUCopyrightComplianceNotice'
   ], function (React, ReactModal, SFUCopyrightComplianceNotice) {
 

--- a/app/jsx/sfu_copyright_compliance_notice/SFUCopyrightComplianceNoticeMoreInfo.jsx
+++ b/app/jsx/sfu_copyright_compliance_notice/SFUCopyrightComplianceNoticeMoreInfo.jsx
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 define([
-  'react'
+  'old_unsupported_dont_use_react'
   ], function (React) {
 
   var SFUCopyrightComplianceNoticeMoreInfo = React.createClass({

--- a/public/javascripts/sfu-modules/copyright_notice_modal_dialog.js
+++ b/public/javascripts/sfu-modules/copyright_notice_modal_dialog.js
@@ -1,7 +1,8 @@
 define([
   'jquery',
+  'old_unsupported_dont_use_react',
   '../jsx/sfu_copyright_compliance_notice/SFUCopyrightComplianceNoticeModalDialog'
-], function($, SFUCopyrightComplianceModalDialog) {
+], function($, React, SFUCopyrightComplianceModalDialog) {
 
     var render = function(formId) {
         React.renderComponent(SFUCopyrightComplianceModalDialog({
@@ -9,7 +10,6 @@ define([
             formId: formId
         }), document.getElementById('wizard_box'));
     };
-
 
     var attachClickHandler = function(formId) {
         var $button = $('#' + formId + ' button.btn-publish');


### PR DESCRIPTION
Instructure changed their config to pull in react 0.12.x, but kept the old 0.11 around as 'old_unsupported_dont_use_react' to keep backcompat. The course checklist was modified to use old_react, so these components need to as well.

Tested on a vagrant VM, works normally. Also verified that the other react components from the original pull (PIA notices) still work.