### PR TITLE
Activate accordion and tab components on course pages, if they exist.

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -245,6 +245,13 @@
 
     });
 
+    // On course pages, activate accordion and tab components, if they exist.
+    utils.onPage(/^\/courses\/\d+\/pages\/[A-Za-z0-9_\-+~<>]+$/, function() {
+        $(document).ajaxComplete(function (event, XMLHttpRequest, ajaxOptions) {
+            $("div.accordion").accordion({header: "h3"});
+            $(".sfu-tabs").tabs();
+        });
+    });
 })(jQuery);
 
 // google analytics


### PR DESCRIPTION
Activate accordion and tab web components on course pages as shown in the Canvas Style Guide. For accordion, 'accordion' must be in the class attribute. For tabs, 'sfu-tabs' must be in the class attribute.