### PR TITLE
Fixed accordion activation for front pages and group pages.

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -245,13 +245,23 @@
 
     });
 
-    // On course pages, activate accordion and tab components, if they exist.
-    utils.onPage(/^\/courses\/\d+\/pages\/[A-Za-z0-9_\-+~<>]+$/, function() {
-        $(document).ajaxComplete(function (event, XMLHttpRequest, ajaxOptions) {
+
+    // On course and wiki pages, activate accordion and tab components, if they exist.
+    utils.onPage(/^\/(courses|groups)\/\d+\/pages\/[A-Za-z0-9_\-+~<>]+$/, function() {
+        $.subscribe('userContent/change', function () {
             $("div.accordion").accordion({header: "h3"});
             $(".sfu-tabs").tabs();
         });
     });
+
+    // A page designated as a front page has a different url.
+    utils.onPage(/^\/(courses|groups)\/\d+\/wiki$/, function() {
+        $.subscribe('userContent/change', function () {
+            $("div.accordion").accordion({header: "h3"});
+            $(".sfu-tabs").tabs();
+        });
+    });
+
 })(jQuery);
 
 // google analytics

--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -245,22 +245,20 @@
 
     });
 
+    // Setup Backbone event handler that will be called when all the content DOM elements 
+    // have been rendered. This will activate the accordion and tab components on the page.
+    function setupAccordionAndTabActivation() {
+        $.subscribe('userContent/change', function () {
+            $("div.accordion").accordion({header: "h3"});
+            $(".sfu-tabs").tabs();
+        });
+    }
 
     // On course and wiki pages, activate accordion and tab components, if they exist.
-    utils.onPage(/^\/(courses|groups)\/\d+\/pages\/[A-Za-z0-9_\-+~<>]+$/, function() {
-        $.subscribe('userContent/change', function () {
-            $("div.accordion").accordion({header: "h3"});
-            $(".sfu-tabs").tabs();
-        });
-    });
-
+    utils.onPage(/^\/(courses|groups)\/\d+\/pages\/[A-Za-z0-9_\-+~<>]+$/, setupAccordionAndTabActivation);
+    
     // A page designated as a front page has a different url.
-    utils.onPage(/^\/(courses|groups)\/\d+\/wiki$/, function() {
-        $.subscribe('userContent/change', function () {
-            $("div.accordion").accordion({header: "h3"});
-            $(".sfu-tabs").tabs();
-        });
-    });
+    utils.onPage(/^\/(courses|groups)\/\d+\/wiki$/, setupAccordionAndTabActivation);
 
 })(jQuery);
 


### PR DESCRIPTION
Fix for INC0083451.
Accordions and tabs weren't working on front pages and group pages because those pages were located at urls different than course page urls and thus not handled by the js code. Added checking for these additional url patterns. Accordions and tabs will now work on course pages, course front pages, group pages and group front pages. Also changed the event that triggers accordion/tabs activation. Instead of listening for an ajaxComplete event, we listen for the Backbone event: 'userContent/change' which is fired in the afterRender event.