### PR TITLE
replace slashes with underscores in gradebook export filename

### DIFF
--- a/app/controllers/gradebook_csvs_controller.rb
+++ b/app/controllers/gradebook_csvs_controller.rb
@@ -23,8 +23,8 @@ class GradebookCsvsController < ApplicationController
   def show
     if authorized_action(@context, @current_user, :manage_grades)
       current_time = Time.zone.now.to_formatted_s(:short)
-      name = t('grades_filename', "Grades") + "-" + @context.name.to_s
-      filename = "#{current_time}_#{name}.csv".gsub(/ /, '_')
+      name = t('grades_filename', "Grades") + "-" + @context.short_name.to_s
+      filename = "#{current_time}_#{name}.csv".gsub(%r{/| }, '_') # SFU MOD - REPLACE SLASH WITH UNDERSCORE
 
       csv_options = {
         include_sis_id: @context.grants_any_right?(@current_user, session, :read_sis, :manage_sis)


### PR DESCRIPTION
When using local storage instead of S3, having a course short name with a slash in it will cause an error (No such file or directory @ rb_sysopen) when trying to export the Gradebook as a CSV. attachment_fu is receiving the slash as part of the file path, and erroring out because it can't find the file.

This is a band-aid fix until I can fix it properly in AttachmentFu and submit it back to Instructure.

Test plan:
create a course with a slash in the short name
(e.g. CHEM 121 / CHEM 122)

attempt to export the gradebook
ensure the gradebook file was exported and
downlaoded correctly
