### PR TITLE
Add "sections" property to the Amaint course API

### DIFF
--- a/vendor/plugins/sfu_api/app/controllers/amaint_controller.rb
+++ b/vendor/plugins/sfu_api/app/controllers/amaint_controller.rb
@@ -70,7 +70,9 @@ class AmaintController < ApplicationController
     # If asking for a specific property then clear hash
     course_hash = {} unless property.nil?
     section_tutorials = SFU::Course.section_tutorials(course_info[1] + course_info[2], course_info.first, course_info[3]) if property.nil? || property.downcase.eql?("sectiontutorials")
-    course_hash["sectionTutorials"] = section_tutorials if !section_tutorials.empty?
+    course_hash["sectionTutorials"] = section_tutorials if section_tutorials.present?
+    sections = SFU::Course.sections(course_info[1] + course_info[2], course_info.first, course_info[3]) if property.nil? || property.downcase.eql?("sections")
+    course_hash["sections"] = sections if sections.present?
     course_title = SFU::Course.title(course_info[1] + course_info[2], course_info.first, course_info[3]) #if property.nil? || property.downcase.eql?("title")
     course_hash["title"] = course_title if property.nil? || property.downcase.eql?("title")
 

--- a/vendor/plugins/sfu_api/app/model/sfu/sfu.rb
+++ b/vendor/plugins/sfu_api/app/model/sfu/sfu.rb
@@ -71,6 +71,27 @@ module SFU
         associated_class
       end
 
+      def sections(course_code, term_code, section)
+        details = info(course_code, term_code)
+        raise "Course info REST API call returned non-array: #{details.inspect}" unless details.is_a?(Array)
+
+        sections = []
+        sections << section.upcase if sections_exists?(details, section)
+
+        if details.present? && is_enrollment_section?(details, section)
+          associated_class = associated_class_for_section(details, section)
+          details.each do |info|
+            class_type = info["course"]["classType"]
+            if class_type.eql?("n") && associated_class == info["course"]["associatedClass"]
+              sections << info["course"]["section"]
+            end
+          end
+        end
+
+        sections
+      end
+
+      # NOTE: This has been superseded by #sections, and may be removed in the future.
       def section_tutorials(course_code, term_code, section)
         details = info(course_code, term_code)
         sections = []


### PR DESCRIPTION
This is part of our implementation of multiple enrollments, in which students are enrolled in *both* lecture and tutorial/lab sections.

The "sections" property returns all sections in a given course, and replaces the older "sectionTutorials" property.

*Side note: In the event that the REST API call returns a `404` or `500` (or more accurately, if the JSON can't be parsed as an Array), an exception will be raised and the output will be a standard Canvas error JSON. Before, it would also have resulted in an error JSON, but the failure will occur at a different, less obvious place: inside `#is_enrollment_section?` because `#any?` is called on an unexpected number (`json_data`).*

Test plan:
* GET `/sfu/api/v1/amaint/course/<course_code>/sections`
* Verify that the JSON result has "sections" that lists all sections