### PR TITLE
Speed up your Vagrant with this one weird trick!

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", type: :nfs
 
   config.vm.provider "virtualbox" do |v|
+
+    v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+
     host = RbConfig::CONFIG['host_os']
 
     # Give VM 1/4 system memory & access to all cpu cores on the host

--- a/provision/callback_plugins/profile_tasks.py
+++ b/provision/callback_plugins/profile_tasks.py
@@ -1,0 +1,67 @@
+import datetime
+import os
+import time
+
+
+class CallbackModule(object):
+    """
+    A plugin for timing tasks
+    """
+    def __init__(self):
+        self.stats = {}
+        self.current = None
+
+    def playbook_on_task_start(self, name, is_conditional):
+        """
+        Logs the start of each task
+        """
+
+        if os.getenv("ANSIBLE_PROFILE_DISABLE") is not None:
+            return
+
+        if self.current is not None:
+            # Record the running time of the last executed task
+            self.stats[self.current] = time.time() - self.stats[self.current]
+
+        # Record the start time of the current task
+        self.current = name
+        self.stats[self.current] = time.time()
+
+    def playbook_on_stats(self, stats):
+        """
+        Prints the timings
+        """
+
+        if os.getenv("ANSIBLE_PROFILE_DISABLE") is not None:
+            return
+
+        # Record the timing of the very last task
+        if self.current is not None:
+            self.stats[self.current] = time.time() - self.stats[self.current]
+
+        # Sort the tasks by their running time
+        results = sorted(
+            self.stats.items(),
+            key=lambda value: value[1],
+            reverse=True,
+        )
+
+        # Just keep the top 10
+        results = results[:10]
+
+        # Print the timings
+        for name, elapsed in results:
+            print(
+                "{0:-<70}{1:->9}".format(
+                    '{0} '.format(name),
+                    ' {0:.02f}s'.format(elapsed),
+                )
+            )
+
+        total_seconds = sum([x[1] for x in self.stats.items()])
+        print("\nPlaybook finished: {0}, {1} total tasks.  {2} elapsed. \n".format(
+                time.asctime(),
+                len(self.stats.items()),
+                datetime.timedelta(seconds=(int(total_seconds)))
+                )
+          )

--- a/provision/canvas/tasks/main.yml
+++ b/provision/canvas/tasks/main.yml
@@ -66,6 +66,7 @@
   sudo: no
   args:
     chdir: /vagrant
+    creates: /home/vagrant/CanvasTestDBSetupDone
 
 - name: db migrate
   shell: RAILS_ENV=production bundle exec rake db:migrate

--- a/provision/canvas/tasks/main.yml
+++ b/provision/canvas/tasks/main.yml
@@ -10,16 +10,16 @@
   service: name=canvas_init state=stopped
   ignore_errors: yes
 
-- name: wait for all vendor/bundle files to close
-  shell: lsof | grep "vendor/bundle" | wc -l
+- name: wait for all canvas gem files to close
+  shell: lsof | grep "/home/vagrant/canvas_gems" | wc -l
   register: lsof_output
   ignore_errors: true
   until: lsof_output.stdout.find("0") != -1
   retries: 10
   delay: 5
 
-- name: delete vendor/bundle
-  file: path=/vagrant/vendor/bundle state=absent force=yes
+- name: delete canvas gems 
+  file: path=/home/vagrant/canvas_gems state=absent force=yes
 
 - name: delete Gemfile.lock
   file: path=/vagrant/Gemfile.lock state=absent
@@ -28,7 +28,7 @@
   sudo: no
   remote_user: vagrant
   shell: >
-    bundle install --path=vendor/bundle --without=sqlite mysql
+    bundle install --path=/home/vagrant/canvas_gems --without=sqlite mysql
   args:
     chdir: /vagrant
 
@@ -60,6 +60,13 @@
     chdir: /vagrant
     creates: /home/vagrant/CanvasDBSetupDone
 
+- name: test db setup
+  shell: RAILS_ENV=test bundle exec rake db:test:reset
+  remote_user: vagrant
+  sudo: no
+  args:
+    chdir: /vagrant
+
 - name: db migrate
   shell: RAILS_ENV=production bundle exec rake db:migrate
   args:
@@ -82,3 +89,4 @@
 - name: update-rc.d canvas_init
   sudo: yes
   shell: update-rc.d canvas_init defaults
+

--- a/provision/canvas/templates/database.yml
+++ b/provision/canvas/templates/database.yml
@@ -2,9 +2,10 @@
 test:
   adapter: postgresql
   encoding: utf8
-  database: canvas_test
+  database: {{canvas_test_database_name}} 
   host: localhost
   username: canvas
+  password: {{canvas_database_password}}
   timeout: 5000
 
 development:

--- a/provision/postgres/tasks/main.yml
+++ b/provision/postgres/tasks/main.yml
@@ -17,6 +17,7 @@
   sudo_user: postgres
   with_items:
     - "{{canvas_database_name}}"
+    - "{{canvas_test_database_name}}"
     - "{{canvas_queue_database_name}}"
   postgresql_db: name={{ item }}
 
@@ -30,5 +31,6 @@
   sudo_user: postgres
   with_items:
     - "{{canvas_database_name}}"
+    - "{{canvas_test_database_name}}"
     - "{{canvas_queue_database_name}}"
   postgresql_user: user={{ canvas_database_user }} db={{ item }} priv=ALL

--- a/provision/vagrant.yml
+++ b/provision/vagrant.yml
@@ -6,6 +6,7 @@
     canvas_admin_email: vagrant@localhost
     canvas_admin_password: vagrant
     canvas_database_name: canvas
+    canvas_test_database_name: canvas_test
     canvas_queue_database_name: canvas_queue
     canvas_database_user: canvas
     canvas_database_password: D79A8D01-6904-4798-8A68-DCDA557987B8


### PR DESCRIPTION
This speeds up the provisioning of a Vagrant box by enabling a couple of
DNS-related options, and moving the bundle install location outside of
the NFS-mounted canvas root and into ~/canvas_gems.

An ansible plugin has been added that outputs timing information has been
added.

```
PLAY RECAP ********************************************************************
canvas | bundle install ----------------------------------------------- 257.93s
canvas | compile assets ----------------------------------------------- 148.07s
dependencies | Add nodesource ------------------------------------------ 21.64s
canvas | test db setup ------------------------------------------------- 14.38s
update apt cache ------------------------------------------------------- 13.26s
dependencies | Update apt cache ----------------------------------------- 8.88s
dependencies | Update npm to latest ------------------------------------- 8.72s
canvas | wait for all canvas gem files to close ------------------------- 6.23s
canvas | stop jobs ------------------------------------------------------ 6.17s
canvas | npm install ---------------------------------------------------- 5.57s
```
The test database is created and initialized.

In my testing, these changes, along with changing the base box config to have all the OS-level dependencies pre-installed, has reduced `vagrant up` time to ~10 minutes.