### PR TITLE
Add multiple enrollments support to the Course Form

### DIFF
--- a/vendor/plugins/sfu_course_form/app/coffeescripts/bundles/course_request_form.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/bundles/course_request_form.coffee
@@ -345,14 +345,14 @@ require [
           section: ui.item.section
           sis_source_id: ui.item.sis_source_id
           title: ui.item.title
-          sectionTutorials: []
+          sections: []
           sectionCode: '' # NOTE: this field is not available with this API call
 
-        # Check if this course has section tutorials. If it does, update the course
+        # Check if this course has sections. If it does, update the course
         $.ajax
-          url: "/sfu/api/v1/amaint/course/#{ui.item.key}/sectionTutorials"
+          url: "/sfu/api/v1/amaint/course/#{ui.item.key}/sections"
           dataType: 'json'
-          success: (data) -> course.addSectionTutorials data.sectionTutorials
+          success: (data) -> course.addSections data.sections
 
         # Check if this course is already in Canvas. If it is, the call will be successful. Otherwise, we'll get a 404.
         $.ajax

--- a/vendor/plugins/sfu_course_form/app/coffeescripts/models/Course.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/models/Course.coffee
@@ -17,12 +17,12 @@ define [
         selected: @selected
         displayName: @displayName()
 
-    addSectionTutorials: (newTutorials) ->
-      # NOTE: does not currently check if course already has section tutorials
-      if newTutorials.length > 0
+    addSections: (newSections) ->
+      # NOTE: does not currently check if course already has sections
+      if newSections.length > 0
         @set
-          sectionTutorials: newTutorials
-          key: "#{@get('key')}:::#{newTutorials.join(',').toLowerCase()}"
+          sections: newSections
+          key: "#{@get('key')}:::#{newSections.join(',').toLowerCase()}"
       this
 
     displayName: -> "#{@get('name')}#{@get('number')} - #{@get('section')} #{@get('title')}"

--- a/vendor/plugins/sfu_course_form/app/coffeescripts/views/courses/CourseView.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/views/courses/CourseView.coffee
@@ -12,7 +12,7 @@ define [
 
     tagName: 'li'
 
-    template: _.template '<div><span class="term tag"><%= term %></span> <%= displayName %><% if (sectionTutorials.length) { %></div><div class="tutorial_sections">&mdash; includes tutorial sections: <%= sectionTutorials.join(", ") %></div><% } %>'
+    template: _.template '<div><span class="term tag"><%= term %></span> <%= displayName %><% if (sections.length) { %></div><div class="tutorial_sections">&mdash; includes these sections: <%= sections.join(", ") %></div><% } %>'
 
     render: ->
       this.$el.html @template @model.toJSON()

--- a/vendor/plugins/sfu_course_form/app/coffeescripts/views/courses/SelectableCourseView.coffee
+++ b/vendor/plugins/sfu_course_form/app/coffeescripts/views/courses/SelectableCourseView.coffee
@@ -7,7 +7,7 @@ define [
 
   class SelectableCourseView extends CourseView
 
-    template: _.template '<div><input type="checkbox" id="chk-course-<%= cid %>-<%= sis_source_id %>" <% if (selected) { %>checked="checked"<% } %> /> <label for="chk-course-<%= cid %>-<%= sis_source_id %>"><span class="term tag"><%= term %></span> <%= displayName %><% if (sectionTutorials.length) { %></div><div class="tutorial_sections">&mdash; includes tutorial sections: <%= sectionTutorials.join(", ") %></div><% } %></label>'
+    template: _.template '<div><input type="checkbox" id="chk-course-<%= cid %>-<%= sis_source_id %>" <% if (selected) { %>checked="checked"<% } %> /> <label for="chk-course-<%= cid %>-<%= sis_source_id %>"><span class="term tag"><%= term %></span> <%= displayName %><% if (sections.length) { %></div><div class="tutorial_sections">&mdash; includes these sections: <%= sections.join(", ") %></div><% } %></label>'
 
     render: ->
       # cid maintains checkbox uniqueness when multiple courses with the same sis_source_id are present

--- a/vendor/plugins/sfu_course_form/app/controllers/course_form_controller.rb
+++ b/vendor/plugins/sfu_course_form/app/controllers/course_form_controller.rb
@@ -13,7 +13,11 @@ class CourseFormController < ApplicationController
     @terms = [@current_term] + future_terms
     # only show current term plus next 2 terms (up to 3 non-nil terms in total)
     @term_options = @terms.compact.take(3).map { |term| [term.name, term.sis_source_id] }
-    roles = SFU::User.roles @sfuid
+    roles = SFU::User.roles(@sfuid) || []
+    unless roles.is_a? (Array)
+      flash[:error] = "Unable to look up your user's account information"
+      return redirect_to dashboard_url
+    end
     @is_student = (roles & %w(undergrad grad fic)).any?
     # deny access unless user has any of the following roles
     unless (roles & %w(staff faculty f_faculty grad other)).any?

--- a/vendor/plugins/sfu_course_form/lib/sfu/course_form/csv_builder.rb
+++ b/vendor/plugins/sfu_course_form/lib/sfu/course_form/csv_builder.rb
@@ -56,7 +56,7 @@ module SFU
           course_array.push [course_id, short_name, long_name, account_id, term, 'active', selected_term.start_at, selected_term.end_at]
 
           # create section csv
-          sections.each { |section| section_array.concat section_csv(term, section, course_id) }
+          sections.each { |section| section_array.concat section_csv(section, course_id) }
 
           # create enrollment csv to default section
           enrollment_array.push [course_id, teacher_sis_user_id, 'teacher', nil, 'active']
@@ -105,7 +105,7 @@ module SFU
               course_array.push course_info[:course]
 
               # create section csv
-              section_array.concat section_csv(course_info[:term], course_info[:sections], course_info[:course_id])
+              section_array.concat section_csv(course_info[:sections], course_info[:course_id])
 
               enrollment_array.concat course_info[:enrollments]
 
@@ -163,12 +163,9 @@ module SFU
         course
       end
 
-      def section_csv(term, sections, course_id)
+      def section_csv(sections, course_id)
         sections = sections.compact.uniq
         sections.map! do |section_info|
-          # Skip Dx00 section if there are other child sections (except in Fall 2013)
-          next if term.to_i != 1137 && sections.count > 1 && section_info[1].to_s.end_with?('00')
-
           [section_info[0], course_id, section_info[1], 'active', nil, nil, nil]
         end
         sections.compact

--- a/vendor/plugins/sfu_course_form/spec/csv_builder_spec.rb
+++ b/vendor/plugins/sfu_course_form/spec/csv_builder_spec.rb
@@ -137,6 +137,21 @@ describe 'A courses request' do
     end
   end
 
+  context 'with duplicate sections' do
+    it 'should only result in a course with unique sections' do
+      @courses_csv, @sections_csv, @enrollments_csv = SFU::CourseForm::CSVBuilder.build('kipling', ['1141:::dupe:::101:::d100:::Repeat Me:::d100,d101,d101'], 2, 'kipling', '55599068', nil, nil, false)
+      courses = CSV.parse(@courses_csv, :headers => true)
+      courses.count.should == 1
+      courses[0]['long_name'].should == 'DUPE101 D100 Repeat Me'
+      courses[0]['account_id'].should == '2'
+      courses[0]['term_id'].should == '1141'
+      sections = CSV.parse(@sections_csv, :headers => true)
+      sections.count.should == 2
+      sections[0]['section_id'] == '1141-dupe-101-d100'
+      sections[1]['section_id'] == '1141-dupe-101-d101'
+    end
+  end
+
 end
 
 describe 'A multiple calendar courses request' do
@@ -177,8 +192,8 @@ describe 'A multiple calendar courses request' do
     it 'should create two D100 courses' do
       verify_courses(%w(1141-easy-240-d100 1141-hard-840-d100))
     end
-    it 'should create child sections only' do
-      verify_sections(3, %w(1141-easy-240-d101 1141-easy-240-d102 1141-hard-840-d101), ['EASY240 D101', 'EASY240 D102', 'HARD840 D101'], %w(1141-easy-240-d100 1141-easy-240-d100 1141-hard-840-d100))
+    it 'should create all sections each' do
+      verify_sections(5, %w(1141-easy-240-d100 1141-easy-240-d101 1141-easy-240-d102 1141-hard-840-d100 1141-hard-840-d101), ['EASY240 D100', 'EASY240 D101', 'EASY240 D102', 'HARD840 D100', 'HARD840 D101'], %w(1141-easy-240-d100 1141-easy-240-d100 1141-easy-240-d100 1141-hard-840-d100 1141-hard-840-d100))
     end
   end
 
@@ -319,8 +334,8 @@ describe 'A cross-list course request' do
     it 'should create a single cross-listed D100/D100 course' do
       verify_courses('1141-easy-240-d100:1141-hard-840-d100')
     end
-    it 'should create child sections only' do
-      verify_sections(3, %w(1141-easy-240-d101 1141-easy-240-d102 1141-hard-840-d101), ['EASY240 D101', 'EASY240 D102', 'HARD840 D101'], '1141-easy-240-d100:1141-hard-840-d100')
+    it 'should create all sections in a single course' do
+      verify_sections(5, %w(1141-easy-240-d100 1141-easy-240-d101 1141-easy-240-d102 1141-hard-840-d100 1141-hard-840-d101), ['EASY240 D100', 'EASY240 D101', 'EASY240 D102', 'HARD840 D100', 'HARD840 D101'], '1141-easy-240-d100:1141-hard-840-d100')
     end
   end
 
@@ -339,8 +354,8 @@ describe 'A cross-list course request' do
     it 'should create a single cross-listed D100/D100 course' do
       verify_courses('1141-easy-240-d100:1141-hard-840-d100')
     end
-    it 'should create child sections / lecture section only' do
-      verify_sections(3, %w(1141-easy-240-d101 1141-easy-240-d102 1141-hard-840-d100), ['EASY240 D101', 'EASY240 D102', 'HARD840 D100'], '1141-easy-240-d100:1141-hard-840-d100')
+    it 'should create all sections in a single course' do
+      verify_sections(4, %w(1141-easy-240-d100 1141-easy-240-d101 1141-easy-240-d102 1141-hard-840-d100), ['EASY240 D100', 'EASY240 D101', 'EASY240 D102', 'HARD840 D100'], '1141-easy-240-d100:1141-hard-840-d100')
     end
   end
 
@@ -349,8 +364,8 @@ describe 'A cross-list course request' do
     it 'should create a single cross-listed D101/D100 course' do
       verify_courses('1141-easy-240-d101:1141-hard-840-d100')
     end
-    it 'should create all sections / child sections only' do
-      verify_sections(4, %w(1141-easy-240-d101 1141-easy-240-d102 1141-easy-240-d103 1141-hard-840-d101), ['EASY240 D101', 'EASY240 D102', 'EASY240 D103', 'HARD840 D101'], '1141-easy-240-d101:1141-hard-840-d100')
+    it 'should create all sections in a single course' do
+      verify_sections(5, %w(1141-easy-240-d101 1141-easy-240-d102 1141-easy-240-d103 1141-hard-840-d100 1141-hard-840-d101), ['EASY240 D101', 'EASY240 D102', 'EASY240 D103', 'HARD840 D100', 'HARD840 D101'], '1141-easy-240-d101:1141-hard-840-d100')
     end
   end
 
@@ -359,8 +374,8 @@ describe 'A cross-list course request' do
     it 'should create a single cross-listed D001/D100 course' do
       verify_courses('1141-easy-240-d001:1141-hard-840-d100')
     end
-    it 'should create all sections / child sections only' do
-      verify_sections(4, %w(1141-easy-240-d001 1141-easy-240-d002 1141-easy-240-d003 1141-hard-840-d101), ['EASY240 D001', 'EASY240 D002', 'EASY240 D003', 'HARD840 D101'], '1141-easy-240-d001:1141-hard-840-d100')
+    it 'should create all sections in a single course' do
+      verify_sections(5, %w(1141-easy-240-d001 1141-easy-240-d002 1141-easy-240-d003 1141-hard-840-d100 1141-hard-840-d101), ['EASY240 D001', 'EASY240 D002', 'EASY240 D003', 'HARD840 D100', 'HARD840 D101'], '1141-easy-240-d001:1141-hard-840-d100')
     end
   end
 

--- a/vendor/plugins/sfu_course_form/spec/csv_builder_spec.rb
+++ b/vendor/plugins/sfu_course_form/spec/csv_builder_spec.rb
@@ -141,7 +141,7 @@ end
 
 describe 'A multiple calendar courses request' do
 
-  before(:all) do
+  before do
     @courses_csv, @sections_csv, @enrollments_csv = SFU::CourseForm::CSVBuilder.build('kipling', selected_courses, 2, 'kipling', '55599068', nil, nil, false)
     @courses = CSV.parse(@courses_csv, :headers => true)
     @sections = CSV.parse(@sections_csv, :headers => true)
@@ -163,7 +163,7 @@ describe 'A multiple calendar courses request' do
   def verify_sections(expected_count, expected_section_ids, expected_names, expected_course_ids)
     @sections.count.should == expected_count
     @sections.each_with_index do |section, index|
-      section['section_id'].start_with?(expected_section_ids[index]).should be_true
+      section['section_id'].start_with?(expected_section_ids[index]).should == true
       section['name'].should == expected_names[index]
       section['course_id'].should == expected_course_ids[index]
       section['status'].should == 'active'
@@ -305,7 +305,7 @@ describe 'A cross-list course request' do
   def verify_sections(expected_count, expected_section_ids, expected_names, expected_course_id)
     @sections.count.should == expected_count
     @sections.each_with_index do |section, index|
-      section['section_id'].start_with?(expected_section_ids[index]).should be_true
+      section['section_id'].start_with?(expected_section_ids[index]).should == true
       section['name'].should == expected_names[index]
       section['course_id'].should == expected_course_id
       section['status'].should == 'active'

--- a/vendor/plugins/sfu_course_form/spec/spec_helper.rb
+++ b/vendor/plugins/sfu_course_form/spec/spec_helper.rb
@@ -1,4 +1,10 @@
 ENV["RAILS_ENV"] = "test"
 require File.expand_path(File.dirname(__FILE__) + "/../../../../config/environment")
-require 'test_help'
+require 'rails/test_help'
 
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    # The `should` syntax is deprecated in RSpec 3; keep it alive until we get a chance to switch to `expect`.
+    c.syntax = [:should, :expect]
+  end
+end


### PR DESCRIPTION
The Start a New Course form now creates courses with all their child sections, and not just either the lecture or tutorial sections. This reverts a special rule that has been in effect since Spring 2014.

In addition to that, the form now has improved error handling, and tests that are compatible with RSpec 3.

Test plan:
* Load the Start a New Course form
* Search for a credit course that have more than one section
* Create the course
* Confirm that the course contains both lecture and tutorial sections