### PR TITLE
SFU Terms API fixes

### DIFF
--- a/vendor/plugins/sfu_api/app/controllers/term_controller.rb
+++ b/vendor/plugins/sfu_api/app/controllers/term_controller.rb
@@ -2,7 +2,7 @@ class TermController < ApplicationController
 
   # get all terms
   def all_terms
-    t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = 2)"])
+    t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = #{Account.default.id})"])
     respond_to do |format|
       format.json {render :json => t}
     end
@@ -10,7 +10,7 @@ class TermController < ApplicationController
 
   # get specific term by sis id
   def term_by_sis_id
-    t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = 2) AND (sis_source_id = '#{params[:sis_id]}')"])
+    t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = #{Account.default.id}) AND (sis_source_id = '#{params[:sis_id]}')"])
     respond_to do |format|
       format.json {render :json => t}
     end
@@ -18,7 +18,7 @@ class TermController < ApplicationController
 
   # get current term
   def current_term
-    t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = 2) AND (:date BETWEEN start_at AND end_at) AND (sis_source_id IS NOT NULL)", {:date => DateTime.now}]).first
+    t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = #{Account.default.id}) AND (:date BETWEEN start_at AND end_at) AND (sis_source_id IS NOT NULL)", {:date => DateTime.now}]).first
     respond_to do |format|
       format.json {render :json => t}
     end

--- a/vendor/plugins/sfu_api/app/controllers/term_controller.rb
+++ b/vendor/plugins/sfu_api/app/controllers/term_controller.rb
@@ -1,54 +1,43 @@
 class TermController < ApplicationController
 
-
   # get all terms
   def all_terms
-    ActiveRecord::Base.include_root_in_json = false
     t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = 2)"])
     respond_to do |format|
       format.json {render :json => t}
     end
-    ActiveRecord::Base.include_root_in_json = true
   end
 
   # get specific term by sis id
   def term_by_sis_id
-    ActiveRecord::Base.include_root_in_json = false
     t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = 2) AND (sis_source_id = '#{params[:sis_id]}')"])
     respond_to do |format|
       format.json {render :json => t}
     end
-    ActiveRecord::Base.include_root_in_json = true
   end
 
   # get current term
   def current_term
-    ActiveRecord::Base.include_root_in_json = false
     t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (root_account_id = 2) AND (:date BETWEEN start_at AND end_at) AND (sis_source_id IS NOT NULL)", {:date => DateTime.now}]).first
     respond_to do |format|
       format.json {render :json => t}
     end
-    ActiveRecord::Base.include_root_in_json = true
   end
 
   # get next n term(s)
   def next_terms
-    ActiveRecord::Base.include_root_in_json = false
     t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (start_at > :date) AND (sis_source_id IS NOT NULL)", {:date => DateTime.now}], :order => "sis_source_id", :limit => params[:num_terms])
     respond_to do |format|
       format.json {render :json => t}
     end
-    ActiveRecord::Base.include_root_in_json = true
   end
 
   # get prev n term(s)
   def prev_terms(num_terms=1)
-    ActiveRecord::Base.include_root_in_json = false
     t = EnrollmentTerm.find(:all, :select => select_fields, :conditions => ["workflow_state = 'active' AND (end_at < :date) AND (sis_source_id IS NOT NULL)", {:date => DateTime.now}], :order => "sis_source_id DESC", :limit => params[:num_terms])
     respond_to do |format|
       format.json {render :json => t}
     end
-    ActiveRecord::Base.include_root_in_json = true
   end
 
   private


### PR DESCRIPTION
Two fixes to the SFU Terms API: 

- ba274d0: replace hard-coded account id with Account.default.id
- 0be9b0c: remove `include_root_in_json` calls: We previously did some shenanigans (a3cf39e) to remove the root element from the SFU terms API. This seems to have broken in a recent deploy (or possibly as far back as Rails 3, who knows). AEM is the main consumer of this API, and Ron already changed his code to expect the root element, so we're not "fixing" it. This simply removes the `include_root_in_json` calls that aren't doing anything.