### PR TITLE
add a sfu rake task to reset account settings after a clone

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,6 +16,10 @@ set :bundle_path, "vendor/bundle"
 set :bundle_without, nil
 set :bundle_flags,  ""
 
+# resets Account.name and Account.lti_guid according to values in sfu.yml
+# don't do this on production
+set :reset_account_settings, true
+
 set :ssh_options, {
   forward_agent: true,
   keys: [File.join(ENV["HOME"], ".ssh", "id_rsa_canvas")],

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 lock '3.2.1'
 
 set :application,   'canvas'
-set :repo_url,      'https://github.com/sfu/canvas-lms.git'
+set :repo_url,      ENV['repo'] || 'https://github.com/sfu/canvas-lms.git'
 set :scm,           'git'
 set :branch,        ENV['branch'] || 'sfu-deploy'
 set :user,          'canvasuser'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,6 +5,7 @@ set :copy_local_tar, "/usr/local/bin/gtar" if `uname` =~ /Darwin/
 set :stage, :production
 set :app_node_prefix, "canvas-ap"
 set :canvas_url, 'https://canvas.sfu.ca'
+set :reset_account_settings, false
 
 role :db,  %w{canvas-mp1.tier2.sfu.ca canvas-mp2.tier2.sfu.ca}
 

--- a/lib/capistrano/tasks/canvas.rake
+++ b/lib/capistrano/tasks/canvas.rake
@@ -64,4 +64,17 @@ namespace :canvas do
     end
   end
 
+  desc "Reset account settings for non-production environments"
+  task :reset_account_settings do
+    next unless fetch(:reset_account_settings)
+    on primary :db do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          stage = fetch :stage
+          execute :rake, "sfu:account_settings[#{stage}]"
+        end
+      end
+    end
+  end
+
 end

--- a/lib/tasks/sfu.rake
+++ b/lib/tasks/sfu.rake
@@ -1,0 +1,28 @@
+require 'yaml'
+
+namespace :sfu do
+  desc 'Reset the default Account name and lti_guid. These values need to be reset after a clone from production.'
+  task :account_settings, [:stage] => :environment do |t, args|
+    stage = args[:stage]
+    raise "You must specify a Canvas Capistrano stage (e.g. testing, staging, etc). `rake sfu:account_settings[stage_name]`" if stage.nil?
+    sfu = YAML.load_file './config/sfu.yml'
+    raise "sfu.yml does not contain a `account_settings` block." if sfu['account_settings'].nil?
+    raise "You specified `#{stage}` as the stage, but no such stage is defined in sfu.yml." unless sfu['account_settings'].include? stage
+
+    account_settings = sfu['account_settings'][stage]
+    a = Account.default
+    puts "Current Account settings:"
+    puts "  name: #{a.name}"
+    puts "  lti_guid: #{a.lti_guid}"
+
+    puts "Resetting account settings:"
+    puts "  name: #{account_settings['name']}"
+    puts "  lti_guid: #{account_settings['lti_guid']}"
+
+    Account.transaction do
+      a.name = account_settings['name']
+      a.lti_guid = account_settings['lti_guid']
+      a.save!
+    end
+  end
+end


### PR DESCRIPTION
Our non-production environments are built by cloning the production environment. Certain settings and values need to be unique across environments. For example, Account.lti_guid is used to identify a specific Canvas installation to an external tool. Canvas Commons doesn't work when identical values are used across environments.

This rake task resets the values for Account.name and Account.lti_guid. It can be run manually (`bundle exec rake sfu:account_settings[stage_name])`, but will also be added to the capistrano deploy for the `testing`, `staging` and `cuttingedge` stages.

The rake tasks gets the values to use for Account.name and Account.lti_guid from `sfu.yml`. I've updated the file in `/usr/local/canvas/config/....`, so it's good to go. To test this on a vagrant box, once provisioned, edit `/vagrant/config/sfu.yml` and add an `account_settings` block:

```
account_settings:
  stage_name:
    name: 'Simon Fraser University (canvas.dev)'
    lti_guid: 'klasjdf9uhksdfha9821hklqwjhesado9fhasdfw98yr32.canvas.dev'
```

The above is an example. `stage_name` can be whatever you want. In reality, `sfu.yml` has stages `cuttingedge`, `testing` and `staging`, which correspond to canvas-edge, canvas-test and canvas-stage.

Once `sfu.yml` is set up:

* `bundle exec rake sfu:account_settings` should throw an error since you didn't specify a stage
* `bundle exec rake sfu:account_settings[blahblahblah]` should throw an error since `sfu.yml` doesn't contain a stage named `blahblahblah` 
* `bundle exec rake sfu:account_settings[stage_name]` (substitute whatever you called your stage in `sfu.yml` for `stage_name`) should succeed.

You can verify the settings worked by checking the values for `Account.default.name` and `Account.default.lti_guid` in the rails console or the database directly. They should match whatever you put in `sfu.yml`