### PR TITLE
Add SFU privacy warning to oauth2 launch confirmation dialog

### DIFF
--- a/app/views/oauth2_provider/confirm.html.erb
+++ b/app/views/oauth2_provider/confirm.html.erb
@@ -15,6 +15,12 @@
   <p>
   <%= mt 'details.allow_application', "%{app_name} is requesting access to your account.", :app_name => @provider.app_name %>
     <br/><br/>
+    <% # SFU MOD - add privacy notice %>
+    By granting access to this application you are agreeing to allow SFU Canvas to send your personal data, such as your name, email address, and potentially other data contained in SFU Canvas to a service neither operated nor controlled by Simon Fraser University.
+    <br/><br/>
+    A summary of what this means to you may be found in the <%= link_to "SFU Cloud Computing FAQ", "https://www.sfu.ca/itservices/info_security/cloud-computing-faq.html", :target => "_blank" %>
+    <br/><br/>
+    <% # END SFU MOD %>
     <%= mt 'details.login_name', "You are logging into this app as %{user_name}.", :user_name => link_to(@current_user.short_name, user_profile_url(@current_user), :popup => true) %>
     <% if @current_user.email.present? && @current_user.email != @current_user.short_name %>
       <br/>


### PR DESCRIPTION
This simply adds some warning text to the oauth2 launch confirmation dialog that a user sees when authorizing an external tool to use their credentials to access canvas on their behalf.

This will go to production as a hotfix so that we can enable Canvas Commons this week.

![screen shot 2015-09-22 at 13 29 43](https://cloud.githubusercontent.com/assets/146111/10030749/262cacb2-612e-11e5-96e1-5379934e448a.png)
