### PR TITLE
Remove SFU MOD for unenroll link in People roster

### DIFF
--- a/app/coffeescripts/views/courses/roster/RosterUserView.coffee
+++ b/app/coffeescripts/views/courses/roster/RosterUserView.coffee
@@ -60,11 +60,6 @@ define [
           ENV.permissions.manage_admin_users
         else
           ENV.permissions.manage_students
-      # SFU MOD CANVAS-224 Only show unenroll link if allowed
-      # User can only be unenrolled here if all of their enrollments are not defined by SIS
-      # canRemoveStudents was added by Instructure in c856b5 but we are keeping our mod for now (gnb 2015-09-01)
-      json.canRemove = _.every(json.enrollments, (en) -> en.sis_source_id == null)
-      # END SFU MOD
 
 
     observerJSON: (json) ->

--- a/app/views/jst/courses/roster/rosterUser.handlebars
+++ b/app/views/jst/courses/roster/rosterUser.handlebars
@@ -49,10 +49,10 @@
       <li><a href="#" data-event="editSections"><i class="icon-edit"></i> {{#t "links.edit_sections"}}Edit Sections{{/t}}</a></li>
       {{/if}}
       <li><a href="{{url}}"><i class="icon-user"></i> {{#t "links.user_details"}}User Details{{/t}}</a></li>
-      {{#if canRemove}} {{!-- SFU MOD - CANVAS-224 Only show unenroll link if allowed --}}
+      {{#if canRemoveStudents}}
       <li class="ui-menu-item"><hr /></li>
       <li><a href="#" data-event="removeFromCourse"><i class="icon-trash"></i> {{#t "links.remove_from_course"}}Remove From Course{{/t}}</a></li>
-      {{/if}} {{!-- SFU MOD - CANVAS-224 Only show unenroll link if allowed --}}
+      {{/if}}
     </ul>
   </div>
   {{/if}}


### PR DESCRIPTION
The mod overrides the visibility of the "Remove From Course" context menu link. Instructure added a similar check in the 2015-09-19 release, so we can now take this mod out.

There is one small implementation difference. Our mod always hid the link if an enrollment is SIS-defined, but their implementation will conditionally show the link if you have the ability to delete the
SIS-defined enrollment (certain admins).

This partially reverts 322d673a9c378e5f272d196c9525aba06e85b6b2, and the two files are now identical to Instructure's version.