### PR TITLE
Refactor Vagrant configuration to use DHCP and allow customization

### DIFF
--- a/Vagrant.md
+++ b/Vagrant.md
@@ -8,7 +8,7 @@ There are a few prerequisites to meet before you can start.
 
 * [Virtualbox](https://docs.vagrantup.com/v2/provisioning/basic_usage.html)
 * [Vagrant](https://www.vagrantup.com/)
-  * Vagrant plugin: [vagrant-hostsupdater](https://github.com/cogitatio/vagrant-hostsupdater)
+  * Vagrant plugin: [vagrant-hostmanager](https://github.com/smdahlen/vagrant-hostmanager)
 * [Ansible](http://www.ansible.com/home)
 
 You can install all of these individually using their GUI installer, or you can use the command line:

--- a/Vagrant.md
+++ b/Vagrant.md
@@ -25,7 +25,7 @@ brew cask install virtualbox
 
 # install vagrant and plugin(s)
 brew cask install vagrant
-vagrant plugin install vagrant-hostsupdater
+vagrant plugin install vagrant-hostmanager
 
 # install ansible
 brew install ansible
@@ -40,9 +40,39 @@ During `vagrant up` and `vagrant halt`, vagrant will attempt to modify your /etc
 Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
 Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd restart
 Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed
-Cmnd_Alias VAGRANT_HOSTSUPDATER_ADD = /bin/sh -c echo "*" >> /etc/hosts
-Cmnd_Alias VAGRANT_HOSTSUPDATER_REMOVE = /usr/bin/sed -i -e /*/ d /etc/hosts
-%admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE, VAGRANT_HOSTSUPDATER_ADD, VAGRANT_HOSTSUPDATER_REMOVE
+Cmnd_Alias VAGRANT_HOSTMANAGER_UPDATE = /bin/cp /Users/YOUR_USER_NAME/.vagrant.d/tmp/hosts.local /etc/hosts
+%admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE, VAGRANT_HOSTMANAGER_UPDATE
+```
+
+**Replace YOUR_USER_NAME with your actual username.**
+
+## Custom Configuration using `vagrantrc.yml`
+
+Placing a YAML file named `vagrantrc.yml` at the root of the canvas directory allows you to customize the Vagrant configuration. The following features are customizable:
+
+* Hostname: By default, the hostname is `canvas.dev`. Setting a `:hostname` property will override this.
+* IP address: DHCP is used by default. Setting an `:ip_address` property will set a static IP.
+* Additional NFS mounts: By default, the canvas root directory is NFS exported and mounted at `/vagrant` on the guest. You can specify additional paths on the host filesystem to be exported and mounted on the guest in a `:mount_directories` list. The `:local_path` property must be the full path on your local disk. The `:mount_at` property must be the full path where the exprort will be mounted.
+* Pre-provision shell script: You can specify shell commands to be called before the main Ansible provisioning starts in a `:pre_provision_script` property.
+* Post-provision shell script: You can specify shell commands to be called after the final shell provisioner in a `:post_provision_script` property.
+
+`vagrantrc.yml` should be ignored in either your global gitignore file or in `.git/info/exclude`
+
+### Example:
+
+The following example sets a custom hostname (instead of `canvas.dev`), a static IP address (instead of DHCP), mounts the Canvas Spaces plugins from the host and runs a pre-provisioner script to set up Canvas Spaces:
+
+```YAML
+:hostname: canvas-spaces-test.dev
+:ip_address: 10.0.5.5
+:mount_directories:
+  -
+    :local_path: '/local/path/to/canvas_spaces'
+    :mount_at: '/vagrant/gems/plugins/canvas_spaces'
+  -
+    :local_path: '/local/path/to/canvas_spaces_client_app'
+    :mount_at: '/vagrant/client_apps/canvas_spaces'
+:pre_provision_script: 'cd /vagrant/client_apps/canvas_spaces && npm install && script/canvas_setup'
 ```
 
 ## TL;DR
@@ -112,6 +142,7 @@ Running `vagrant up` and some of the provisioning steps creates some files that 
 * `.vagrant`
 * `vendor/bundle`
 * `/vendor/plugins/*/public/*/compiled/`
+* `vagrantrc.yml`
 
 Editing the Canvas `.gitignore` file often causes conflicts, so instead you should do one of the following:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,17 +1,46 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require 'yaml'
+vagrantrc = YAML.load_file('vagrantrc.yml') rescue {}
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+unless Vagrant.has_plugin?("vagrant-hostmanager")
+  puts "You do not appear to have the `vagrant-hostmanager` plugin installed.\nPlease run `vagrant plugin install vagrant-hostmanager` and try again.\n\n"
+  exit 1
+end
+
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
   config.vm.box = "grahamb/ubuntu-trusty64-uid501"
 
-  config.vm.network :private_network, ip: '192.168.50.50'
-  config.vm.hostname = "canvas.dev"
-  config.hostsupdater.aliases = ["files.canvas.dev"]
+  network_type = 'dhcp' unless vagrantrc[:ip_address]
+  if network_type == 'dhcp'
+    config.vm.network :private_network, type: 'dhcp'
+  else
+    config.vm.network :private_network, ip: vagrantrc[:ip_address]
+  end
+
+  config.vm.hostname = vagrantrc[:hostname] || "canvas.dev"
+  files_domain = "files.#{config.vm.hostname}"
+
+  config.hostmanager.ip_resolver = proc do |vm, resolving_vm|
+    if vm.id
+      `VBoxManage guestproperty get #{vm.id} "/VirtualBox/GuestInfo/Net/1/V4/IP"`.split()[1]
+    end
+  end
+  config.hostmanager.enabled = true
+  config.hostmanager.manage_host = true
+  config.hostmanager.aliases = [ "files.#{config.vm.hostname}" ]
 
   config.vm.synced_folder ".", "/vagrant", type: :nfs
+  vagrantrc[:mount_directories].to_a.each do |d|
+    local_path_exists = File.exists? d[:local_path]
+    config.vm.synced_folder d[:local_path], d[:mount_at], type: :nfs if local_path_exists
+  end
 
   config.vm.provider "virtualbox" do |v|
 
@@ -38,6 +67,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     v.customize ["modifyvm", :id, "--cpus", cpus]
   end
 
+  config.vm.provision :shell, :inline => vagrantrc[:pre_provision_script], run: 'always' if vagrantrc[:pre_provision_script]
 
   config.vm.provision "ansible" do |ansible|
     ansible.verbose  = "vvv"
@@ -45,5 +75,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provision :shell, :inline => "sudo service canvas_init restart && sudo service apache2 restart", run: "always"
+  config.vm.provision :shell, :inline => vagrantrc[:post_provision_script], run: 'always' if vagrantrc[:post_provision_script]
 
 end

--- a/provision/dependencies/tasks/main.yml
+++ b/provision/dependencies/tasks/main.yml
@@ -40,7 +40,3 @@
 - name: Remove ruby 2.0
   sudo: yes
   apt: pkg=ruby2.0 state=absent
-
-- name: Update npm to latest
-  sudo: yes
-  shell: npm -g install npm

--- a/vagrantrc.yml.example
+++ b/vagrantrc.yml.example
@@ -1,0 +1,11 @@
+:hostname: canvas-new-feature.dev
+:ip_address: 10.10.10.10
+:mount_directories:
+  -
+    :local_path: '/local/path/to/canvas_spaces'
+    :mount_at: '/vagrant/gems/plugins/canvas_spaces'
+  -
+    :local_path: '/local/path/to/canvas_spaces_client_app'
+    :mount_at: '/vagrant/client_apps/canvas_spaces'
+:pre_provision_script: 'cd /vagrant/client_apps/canvas_spaces && npm install && script/canvas_setup'
+:post_provision_script: 'echo "All Done!"'


### PR DESCRIPTION
The commit improves the Vagrant provisioning process:

# Default to DHCP instead of a static IP

Previously, 192.168.50.50 was baked into the `Vagrantfile`. This would cause issues if you had two Canvas vagrant VMs running at the same time. Now, we default to DHCP (see Important Notes below).

# Allow customization without editing `Vagrantfile`

The configuration and provisioning for the Vagrant environment is defined in `Vagrantfile`. This includes network settings, NFS mounts, etc. Because this file is checked into git, editing it to customize your local environment is a pain. Now, by creating a `vagrantrc.yml` file, you can customize some aspects of the setup:

* Hostname: By default, the hostname is `canvas.dev`. Setting a `:hostname` property will override this.
* IP address: DHCP is used by default. Setting an `:ip_address` property will set a static IP.
* Additional NFS mounts: By default, the canvas root directory is NFS exported and mounted at `/vagrant` on the guest. You can specify additional paths on the host filesystem to be exported and mounted on the guest in a `:mount_directories` list. The `:local_path` property must be the full path on your local disk. The `:mount_at` property must be the full path where the exprort will be mounted.
* Pre-provision shell script: You can specify shell commands to be called before the main Ansible provisioning starts in a `:pre_provision_script` property.
* Post-provision shell script: You can specify shell commands to be called after the final shell provisioner in a `:post_provision_script` property.

See `vagrantrc.yml.example` for a full example file.

`vagrantrc.yml` should be ignored in either your global gitignore file or in `.git/info/exclude`

# Important Notes

The previous setup used the `vagrant-hostsupdater` plugin to manage the `/etc/hosts` file. That plugin doesn't work with DHCP. It has been replaced by the `vagrant-hostmanager` plugin. If you attempt to `vagrant up` without this plugin installed, Vagrant will throw an error and stop. To remove the old plugin and install the new one: `vagrant plugin uninstall vagrant-hostsupdater ; vagrant plugin install vagrant-hostmanager`

You will need to edit `/etc/sudoers` (use `visudo` to do this) and  add the command used by `vagrant-hostmanager` so that it doesn't prompt for an admin password during `vagrant up` and `vagrant destroy`.

```
# Vagrant
Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd restart
Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed
Cmnd_Alias VAGRANT_HOSTMANAGER_UPDATE = /bin/cp /Users/YOUR_USER_NAME/.vagrant.d/tmp/hosts.local /etc/hosts
%admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE, VAGRANT_HOSTMANAGER_UPDATE
```

**Replace YOUR_USER_NAME with your actual username**