### PR TITLE
Fix PIA notice NUL character and layout

### DIFF
--- a/public/sfu/css/sfu.css
+++ b/public/sfu/css/sfu.css
@@ -171,9 +171,10 @@ body.modal #footer {
 }
 
 .SFUPrivacyNotice .icon-warning:after {
-    content: "\00";
+    content: "\a0";
 }
 
 .SFUPrivacyNotice.alert {
+    padding: 0.25em 1em;
     color: #695129;
 }


### PR DESCRIPTION
Replace NUL (which was rendered as � in some browsers) with non-breaking space, and add padding around the notice.

**Before:**
![before](https://cloud.githubusercontent.com/assets/916029/10233150/b5f7a332-6841-11e5-98f4-c9c1208893c0.png)

---

**After:**
![after](https://cloud.githubusercontent.com/assets/916029/10233151/b9e56a60-6841-11e5-9d11-75e5b898c03a.png)