### PR TITLE
Move setting persistent js_env values into ApplicationController#js_env

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -133,6 +133,12 @@ class ApplicationController < ActionController::Base
       @js_env[:TOURS] = tours_to_run
 
       @js_env[:lolcalize] = true if ENV['LOLCALIZE']
+
+      # SFU MOD: Add SFU entries to js_env
+      @js_env[:APP_NODE] = Socket.gethostname().split('.')[0]
+      @js_env[:RELEASE] = File.dirname(__FILE__)
+      @js_env[:CANVAS_SPACES_ENABLED] = PluginSetting.find_by_name(:canvas_spaces).disabled.! rescue false
+      # END SFU MOD
     end
 
     hash.each do |k,v|

--- a/config/initializers/aaa_sfu_misc.rb
+++ b/config/initializers/aaa_sfu_misc.rb
@@ -1,4 +1,3 @@
 Rails.configuration.to_prepare do
   require_dependency 'aaa_sfu_misc/test_cluster'
-  require_dependency 'aaa_sfu_misc/jsenv'
 end

--- a/lib/aaa_sfu_misc/jsenv.rb
+++ b/lib/aaa_sfu_misc/jsenv.rb
@@ -1,8 +1,0 @@
-ApplicationController.class_eval do
-  before_filter :add_node_name_to_jsenv
-  def add_node_name_to_jsenv
-    appnode = Socket.gethostname().split('.')[0]
-    release_dir = File.dirname(__FILE__)
-    js_env(:APP_NODE => appnode, :RELEASE => release_dir)
-  end
-end


### PR DESCRIPTION
Instructure changed how js_env operates in ddf6184 and it broke our monkeypatch. This moves the setting of our persistent js_env values into the main ApplicationControlller#js_env method, wrapped in a SFU MOD. This is the less-dirty approach and has the advantage of likely throwing a conflict if Instructure changes something in there again.

There is an accompanying commit (sfu/canvas-spaces@d9e0742fc17652a6baa1801d6cfe69c4cd851132) for Canvas Spaces that removes a similar monkeypatch; its end-result is part of this patch.