### PR TITLE
Really remove dashboard sidebar SFU MOD in users_controller

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -527,23 +527,13 @@ class UsersController < ApplicationController
   end
 
   def cached_upcoming_events(user)
-    # SFU MOD 2014-11-10
-    # Dashboard sidebar loading is failing with  _dump_data is defined for class Proc error
-    # Disabling caching the upcoming_events data as a workaround while we investigate
-
     Rails.cache.fetch(['cached_user_upcoming_events', user].cache_key,
       :expires_in => 3.minutes) do
       user.upcoming_events :contexts => ([user] + user.cached_contexts)
     end
-    user.upcoming_events :contexts => ([user] + user.cached_contexts)
-    # END SFU MOD
   end
 
   def cached_submissions(user, upcoming_events)
-    # SFU MOD 2014-11-10
-    # Dashboard sidebar loading is failing with  _dump_data is defined for class Proc error
-    # Disabling caching the user_submissions data as a workaround while we investigate
-
     Rails.cache.fetch(['cached_user_submissions', user].cache_key,
       :expires_in => 3.minutes) do
       assignments = upcoming_events.select{ |e| e.is_a?(Assignment) }
@@ -553,13 +543,6 @@ class UsersController < ApplicationController
           where(:assignment_id => shard_assignments, :user_id => user)
       end
     end
-    assignments = upcoming_events.select{ |e| e.is_a?(Assignment) }
-    Shard.partition_by_shard(assignments) do |shard_assignments|
-      Submission.
-        select([:id, :assignment_id, :score, :workflow_state]).
-        where(:assignment_id => shard_assignments, :user_id => user)
-    end
-    # END SFU MOD
   end
 
   def prepare_current_user_dashboard_items


### PR DESCRIPTION
We previously "removed" this mod in b9d496d, but didn't fully remove it: the instructure code was restored, but our actual mod (below the cache code) was kept. This caused issues fetching the sidebar after the deploy on 2016-02-02.

This commit restores the file to the instructure version as at the 2016-01-09 release. Already hotfixed in place on production.
