### PR TITLE
On People page, show Display Name for students' view and Full Name and Display Name for teachers and TA's view

### DIFF
--- a/app/views/jst/courses/roster/rosterUser.handlebars
+++ b/app/views/jst/courses/roster/rosterUser.handlebars
@@ -2,7 +2,15 @@
   {{>avatar}}
 </td>
 <td>
-  <a href="{{html_url}}" class="roster_user_name">{{name}}</a>
+  <a href="{{html_url}}" class="roster_user_name">
+      {{! SFU MOD}}
+      {{#if canViewSisIdColumn}}
+          {{name}}（{{short_name}}）
+      {{else}}
+          {{short_name}}
+      {{/if}}
+      {{! END SFU MOD}}
+  </a>
   {{#if isPending}}<span class="label label-info" title="{{#t "pending_acceptance_explanation"}}This user has not yet accepted the invitation to the course{{/t}}">{{#t "pending_acceptance_of_invitation"}}pending{{/t}}</span>{{/if}}
   {{#if isInactive}}<span class="label" title="{{#t}}This user is currently not able to access the course{{/t}}">{{#t}}inactive{{/t}}</span>{{/if}}
 </td>


### PR DESCRIPTION


The reason we do this is that instructors would like to view all the users with both legal full name and display name participating in the course on People page, while many students would like their classmates to see their Display Name on People page rather than legal Full Name to avoid embarrassment and to be consistent with their names in discussions, announcements, etc.