### PR TITLE
Fix db migration error in local storage

### DIFF
--- a/db/migrate/20160322204834_drop_zip_file_imports.rb
+++ b/db/migrate/20160322204834_drop_zip_file_imports.rb
@@ -20,6 +20,11 @@ class DropZipFileImports < ActiveRecord::Migration
           end
         else
           child.uploaded_data = root.open
+
+          # SFU MOD
+          child.root_attachment_id = nil
+          child.filename ||= root.filename
+          # END SFU MOD
         end
         child.save!
         Attachment.where(root_attachment_id: root).where.not(:id => child).update_all(root_attachment_id: child)


### PR DESCRIPTION
Set the following two fields again, since the cmd above resets the two fields and causes db migration fail in local stroage