### PR TITLE
Temporarily suppress mobile app error (CANVAS-261)

### DIFF
--- a/app/controllers/communication_channels_controller.rb
+++ b/app/controllers/communication_channels_controller.rb
@@ -154,7 +154,7 @@ class CommunicationChannelsController < ApplicationController
         return render :json => { errors: { type: 'Push is only supported when using an access token'}}, status: :bad_request
       end
       if !@access_token.developer_key.try(:sns_arn)
-        return render :json => { errors: { type: 'SNS is not configured for this developer key'}}, status: :bad_request
+        return render :json => { errors: { type: 'SNS is not configured for this developer key'}}, status: 200 # SFU MOD - Temporarily suppress mobile app error (CANVAS-261)
       end
       endpoint = @current_user.notification_endpoints.where(token: params[:communication_channel][:token]).first
       endpoint ||= @access_token.notification_endpoints.create!(token: params[:communication_channel][:token])


### PR DESCRIPTION
Version 3.14.2 of the iOS Canvas app appears to create a `TYPE_PUSH` communication channel if the user has push notifications enabled. This feature requires AWS SNS to be configured, so the user gets an error upon app launch/login.

This fix suppresses the error by returning an expected response status.