### PR TITLE
Migrate APIs deprecated in Rails 4.1

### DIFF
--- a/gems/plugins/sfu_copyright/app/controllers/copyright_api_controller.rb
+++ b/gems/plugins/sfu_copyright/app/controllers/copyright_api_controller.rb
@@ -25,8 +25,8 @@ class CopyrightApiController < ApplicationController
     end
 
     # Randomly select a course and instructor
-    course = courses.first(:order => 'RANDOM()')
-    teacher = course.teachers.first(:order => 'RANDOM()')
+    course = courses.order('RANDOM()').first
+    teacher = course.teachers.order('RANDOM()').first
 
     # Determine the SFU Computing ID and email address of the instructor
     # NOTE: The course could (very rarely) be teacher-less

--- a/gems/plugins/sfu_course_form/app/controllers/course_form_controller.rb
+++ b/gems/plugins/sfu_course_form/app/controllers/course_form_controller.rb
@@ -86,11 +86,11 @@ class CourseFormController < ApplicationController
   end
 
   def current_term
-    EnrollmentTerm.find(:all, :conditions => ["workflow_state = 'active' AND (:date BETWEEN start_at AND end_at)", {:date => DateTime.now}]).first
+    EnrollmentTerm.active.find_by(':date BETWEEN start_at AND end_at', {:date => DateTime.now})
   end
 
   def future_terms
-    EnrollmentTerm.find(:all, :conditions => ["workflow_state = 'active' AND (:date <= start_at)", {:date => DateTime.now}], :order => 'sis_source_id')
+    EnrollmentTerm.active.where(':date <= start_at', {:date => DateTime.now}).order(:sis_source_id)
   end
 
 end

--- a/gems/plugins/sfu_course_form/lib/sfu/course_form/csv_builder.rb
+++ b/gems/plugins/sfu_course_form/lib/sfu/course_form/csv_builder.rb
@@ -235,7 +235,7 @@ module SFU
       end
 
       def self.term(term_code)
-        EnrollmentTerm.find(:all, :conditions => ["workflow_state = 'active' AND sis_source_id = :term", {:term => term_code}]).first
+        EnrollmentTerm.active.find_by(sis_source_id: term_code)
       end
 
       def csv_string(data)


### PR DESCRIPTION
* Old-style finder option hashes - e.g. `.find(:all, conditions: ...)`
* `:distinct` option in `Relation#count`