### PR TITLE
Fix unsubmittable User Settings form (CANVAS-262)

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -133,7 +133,7 @@
 
             // CANVAS-253 Temporarily make full/sortable names read-only
             $fieldsToLock.removeClass('display_data').addClass('edit_or_show_data');
-            $fieldsToLock.siblings('input').remove();
+            $fieldsToLock.siblings('input').hide();
 
             // CANVAS-254 Add verbiage about Display Name
             $helpText.append('<br />Changing this will only affect your display name within Canvas, ' +


### PR DESCRIPTION
In CANVAS-253, we hid the Full Name and Sortable Name fields because we didn't want users to change those. However, a recent change in Canvas core added a client-side validation that checks for the presense of those fields. This prevented all users from making any changes to their user settings.

This is fixed by making our mod less intrusive. We now hide the fields using `hide()`, rather than the more forceful `remove()`.

Test plan:

* Go to your User Settings (Account > Settings)
* Click Edit Settings
* Verify that Full Name and Sortable Name are still hidden
* Click Update Settings without making any changes
* Verify successful submission and lack of "Required field" error