### PR TITLE
Downcase class_type field when comparing to data from AOBRest

### DIFF
--- a/gems/plugins/sfu_api/app/model/sfu/sfu.rb
+++ b/gems/plugins/sfu_api/app/model/sfu/sfu.rb
@@ -81,8 +81,8 @@ module SFU
         if details.present? && is_enrollment_section?(details, section)
           associated_class = associated_class_for_section(details, section)
           details.each do |info|
-            class_type = info["course"]["classType"]
-            if class_type.downcase.eql?("n") && associated_class == info["course"]["associatedClass"]
+            class_type = info["course"]["classType"].to_s.downcase
+            if class_type.eql?("n") && associated_class == info["course"]["associatedClass"]
               sections << info["course"]["section"]
             end
           end

--- a/gems/plugins/sfu_api/app/model/sfu/sfu.rb
+++ b/gems/plugins/sfu_api/app/model/sfu/sfu.rb
@@ -82,7 +82,7 @@ module SFU
           associated_class = associated_class_for_section(details, section)
           details.each do |info|
             class_type = info["course"]["classType"]
-            if class_type.eql?("n") && associated_class == info["course"]["associatedClass"]
+            if class_type.downcase.eql?("n") && associated_class == info["course"]["associatedClass"]
               sections << info["course"]["section"]
             end
           end


### PR DESCRIPTION
The format in AOBRest changed and the class_type field is returned in uppercase. Convert to lowercase when comparing.