### PR TITLE
Remove unused @numberOfFrozenCols from Gradebook

### DIFF
--- a/app/coffeescripts/gradebook/Gradebook.coffee
+++ b/app/coffeescripts/gradebook/Gradebook.coffee
@@ -120,8 +120,6 @@ define [
       @showInactiveEnrollments =
         @options.settings['show_inactive_enrollments'] == "true"
       @totalColumnInFront = UserSettings.contextGet 'total_column_in_front'
-      @numberOfFrozenCols = if @totalColumnInFront then 3 else 2
-      ++@numberOfFrozenCols # SFU MOD - CANVAS-188 Add extra column for SIS ID
       @gradingPeriods = GradingPeriodsApi.deserializePeriods(@options.active_grading_periods)
       if @options.grading_period_set
         @gradingPeriodSet = GradingPeriodSetsApi.deserializeSet(@options.grading_period_set)


### PR DESCRIPTION
`@numberOfFrozenCols` was removed in an upstream change:

  > instructure/canvas-lms@62db47a269d68126c4e7183effbddc0d55285b20

Our SFU MOD to modify `@numberOfFrozenCols` is no longer needed because the frozen column count is now determined by the length of `@parentColumns`, which is where we have always added the SIS ID column.

This commit should not result in any functional changes.