### PR TITLE
Fix deprecation warnings in sfu_stats

### DIFF
--- a/gems/plugins/sfu_stats/app/controllers/stats_controller.rb
+++ b/gems/plugins/sfu_stats/app/controllers/stats_controller.rb
@@ -54,7 +54,7 @@ class StatsController < ApplicationController
 
   def courses_for_term(term_id, fields='*')
     if term_id == 'current'
-      term_id = current_term || default_term
+      term_id = current_term.id || default_term.id
     end
     workflow_state_translation = {
       "available" => "published",


### PR DESCRIPTION
Rails is throwing a deprecation warning when passing in an ActiveRecord object to `find`. Fixed by passing in the ID directly.