### PR TITLE
Fix course image uploads on local storage (CANVAS-263)

### DIFF
--- a/app/jsx/course_settings/actions.js
+++ b/app/jsx/course_settings/actions.js
@@ -192,9 +192,15 @@ import 'compiled/jquery.rails_flash_notifications'
                     formData.append('file', file);
                     ajaxLib.post(response.data.upload_url, formData)
                            .then((response) => {
-                             return ajaxLib.get(successUrl).then((successResp) => {
-                               dispatch(this.prepareSetImage(successResp.data.url, successResp.data.id, courseId, ajaxLib));
-                             })
+                             // SFU MOD CANVAS-263 Temp fix for course image upload
+                             if (successUrl) {
+                               return ajaxLib.get(successUrl).then((successResp) => {
+                                 dispatch(this.prepareSetImage(successResp.data.url, successResp.data.id, courseId, ajaxLib));
+                               })
+                             } else {
+                               dispatch(this.prepareSetImage(response.data.url, response.data.id, courseId, ajaxLib));
+                             }
+                             // END SFU MOD
                            })
                            .catch((response) => {
                               dispatch(this.errorUploadingImage());


### PR DESCRIPTION
This is a temporary fix. It reverts to the previous behaviour if `successUrl` is not available.

Test plan:

* Go to Settings in any course and upload an image
* Verify that the upload works