### PR TITLE
Restore jqueryUI accordion functionality removed by Canvas commit.

### DIFF
--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -6,6 +6,10 @@
 
  */
 
+!function(s,d,url,e,p){
+  e=d.createElement(s),p=d.getElementsByTagName(s)[0];e.async=1;e.src=url;p.parentNode.insertBefore(e,p)
+}('script', document, 'https://unpkg.com/widgetize-canvas-lms-user-content');
+
 (function ($) {
   var utils = {
     onPage (regex, fn) {

--- a/public/sfu/js/sfu.js
+++ b/public/sfu/js/sfu.js
@@ -6,6 +6,9 @@
 
  */
 
+// Workaround which restores accordion functionality removed from Canvas.
+// See: 'https://github.com/ryankshaw/widgetize-canvas-lms-user-content'
+
 !function(s,d,url,e,p){
   e=d.createElement(s),p=d.getElementsByTagName(s)[0];e.async=1;e.src=url;p.parentNode.insertBefore(e,p)
 }('script', document, 'https://unpkg.com/widgetize-canvas-lms-user-content');


### PR DESCRIPTION
This is a workaround which restores jqueryUI accordion functionality removed by the following commit: https://github.com/instructure/canvas-lms/commit/44ed07d8d61a296e82382974e5c96d098aa851fb

Taken from: 'https://github.com/ryankshaw/widgetize-canvas-lms-user-content'