### PR TITLE
Show Display Name in course group index

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -274,6 +274,13 @@ class GroupsController < ApplicationController
 
     respond_to do |format|
       format.html do
+        
+        # SFU MOD: add ENV.permissions to groups index page - for sfu/canvas-lms-#267
+        js_env permissions: {
+          read_sis: @context.grants_any_right?(@current_user, session, :read_sis, :manage_sis)
+        }
+        # END SFU MOD
+
         @categories  = @context.group_categories.order("role <> 'student_organized'", GroupCategory.best_unicode_collation_key('name')).preload(:root_account)
         @user_groups = @current_user.group_memberships_for(@context) if @current_user
 

--- a/app/jsx/groups/components/Group.js
+++ b/app/jsx/groups/components/Group.js
@@ -112,7 +112,12 @@ import natcompare from 'compiled/util/natcompare'
           <ul ref="memberList" className="student-group-list clearfix" aria-label={I18n.t('group members')} tabIndex="0" role="list">
             {this.props.group.users.map(u => {
             var isLeader = u.id == leaderId;
-            var name = u.name || u.display_name;
+
+            { /*  SFU MOD: show display name if user does not have read_sis permissions */ }
+            { /*  Fixes sfu/canvas-lms:#267 */ }
+            var name = ENV.permissions.read_sis ? u.name : u.short_name || u.name;
+            { /* END SFU MOD */ }
+            
             var leaderBadge = isLeader ? <i className="icon-user" aria-hidden="true"></i> : null;
             return <li tabIndex="0" role="listitem" key={u.id}><span className="screenreader-only">{isLeader ? I18n.t('group leader %{user_name}', {user_name: name}) : name}</span><span aria-hidden="true">{name} {leaderBadge}</span></li>;
             })}


### PR DESCRIPTION
Fixes #267 

The course group index page (e.g. canvas.sfu.ca/courses/:id/groups) shows the Full Name field to student users (e.g. users without `read_sis` permissions). This seems to be an exception to the other places where we have modified the student view UI to show the Display Name if one is set (e.g. the course roster). The Display Name is already shown within the group itself.

Test Plan:
- create a course with some students
- set the display name for a student to something other than their full name
- view the groups page for the course as both a student (read_sis=false) and as an instructor or admin (read_sis=true)

Expected Result:
- For the student view, the Display Name should be used
- For the teacher/admin view, the Full Name should be used

Notes:
- I've added `{ permissions: { read_sis: true|false } }` to js_env so that this mod uses the same scheme as the course roster page for determining whether a user should see the full or display name