### PR TITLE
Fix SQL enforcement issue in Copyright Survey API (CANVAS-267)

### DIFF
--- a/gems/plugins/sfu_copyright/app/controllers/copyright_api_controller.rb
+++ b/gems/plugins/sfu_copyright/app/controllers/copyright_api_controller.rb
@@ -25,8 +25,8 @@ class CopyrightApiController < ApplicationController
     end
 
     # Randomly select a course and instructor
-    course = courses.order('RANDOM()').first
-    teacher = course.teachers.order('RANDOM()').first
+    course = courses.order(Arel.sql('RANDOM()')).first
+    teacher = course.teachers.order(Arel.sql('RANDOM()')).first
 
     # Determine the SFU Computing ID and email address of the instructor
     # NOTE: The course could (very rarely) be teacher-less


### PR DESCRIPTION
The use of non-attribute arguments (in this case, calling the `RANDOM()` function) in a query is deprecated in Rails 5.2 and disallowed in 6.0. Additionally, Canvas is enforcing this new behaviour early in Rails 5.1.

Related commit: https://github.com/instructure/canvas-lms/commit/e8f0be2f5ea1eb4114b306bf6952a8b5523d079d

The workaround is to wrap known safe values in `Arel.sql()` before passing it into `order()`. We know it is safe in this case because the value does not depend on user inputs.

See also: https://github.com/rails/rails/issues/32995

Test plan:

1. Call the Copyright Survey API as usual
2. Verify that it does not fail with a 500 Internal Server Error